### PR TITLE
fix(ci): install npm-publish deps from monorepo root

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -37,16 +37,17 @@ jobs:
       - name: Cache dependencies
         uses: actions/cache@v4
         with:
-          path: app/node_modules
-          key: bun-${{ hashFiles('**/bun.lockb') }}
+          path: node_modules
+          key: bun-${{ hashFiles('**/bun.lock') }}
           restore-keys: |
             bun-
 
       - name: Install dependencies
+        working-directory: .
         run: bun install --frozen-lockfile
 
       - name: Type check shared types
-        working-directory: ../shared
+        working-directory: shared
         run: bunx tsc --noEmit
 
       - name: Type check application


### PR DESCRIPTION
## Summary
- Apply same fix from 1b93977 to npm-publish workflow
- Run bun install from root for proper workspace hoisting
- Fix cache path to root node_modules
- Fix cache key to use bun.lock (not bun.lockb)
- Fix shared type-check working directory

## Context
The npm-publish workflow was failing because it installed deps only in `app/` directory, but needed to run type-check on `shared/` which requires deps at the monorepo root.

## Test plan
- [ ] Merge PR
- [ ] Create new tag (e.g., v2.0.1)
- [ ] Verify workflow completes successfully
- [ ] Verify GitHub Release is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)