### PR TITLE
fix(ci): resolve Zod version conflict in npm-publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,9 +11,6 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    defaults:
-      run:
-        working-directory: app
 
     steps:
       - name: Checkout repository
@@ -28,6 +25,7 @@ jobs:
 
       - name: Verify tag matches package version
         if: startsWith(github.ref, 'refs/tags/')
+        working-directory: app
         run: |
           TAG_VERSION=${GITHUB_REF#refs/tags/v}
           PKG_VERSION=$(cat package.json | grep '"version"' | head -1 | awk -F: '{ print $2 }' | sed 's/[", ]//g')
@@ -40,8 +38,8 @@ jobs:
       - name: Cache dependencies
         uses: actions/cache@v4
         with:
-          path: app/node_modules
-          key: bun-${{ hashFiles('**/bun.lockb') }}
+          path: node_modules
+          key: bun-${{ hashFiles('**/bun.lock') }}
           restore-keys: |
             bun-
 
@@ -49,9 +47,11 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Type check application
+        working-directory: app
         run: bunx tsc --noEmit
 
       - name: Lint
+        working-directory: app
         run: bun run lint
 
       - name: Install uv (required for ADW MCP tools)
@@ -60,12 +60,15 @@ jobs:
           enable-cache: true
 
       - name: Run tests
+        working-directory: app
         run: bun test --coverage --coverage-reporter=text
 
       - name: Build
+        working-directory: app
         run: bun run build
 
       - name: Verify package metadata
+        working-directory: app
         run: |
           echo "Verifying package.json structure..."
           if ! cat package.json | grep -q '"bin"'; then
@@ -79,6 +82,7 @@ jobs:
 
       - name: Set pre-release version for develop
         if: github.ref == 'refs/heads/develop'
+        working-directory: app
         run: |
           CURRENT_VERSION=$(node -p "require('./package.json').version")
           TIMESTAMP=$(date +%Y%m%d%H%M%S)
@@ -87,6 +91,7 @@ jobs:
           npm version ${PRE_VERSION} --no-git-tag-version
 
       - name: Publish to npm
+        working-directory: app
         run: |
           if [ "${{ github.ref }}" = "refs/heads/develop" ]; then
             echo "Publishing to 'next' tag..."
@@ -100,6 +105,7 @@ jobs:
 
       - name: Create GitHub Release
         if: startsWith(github.ref, 'refs/tags/')
+        working-directory: app
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -111,6 +117,7 @@ jobs:
 
       - name: Generate publish summary
         if: always()
+        working-directory: app
         run: |
           echo "## npm Publish Summary" >> ${GITHUB_STEP_SUMMARY}
           echo "" >> ${GITHUB_STEP_SUMMARY}


### PR DESCRIPTION
## Summary

- Fix npm-publish workflow failing with Zod TypeScript errors
- Install dependencies from root instead of `app/` directory to properly resolve monorepo workspace dependencies
- Matches the pattern used by `app-ci.yml` which works correctly

## Root Cause

The workflow used `defaults: run: working-directory: app` which caused `bun install` to run from `app/` instead of root. With the monorepo workspace configuration in root `package.json`, this created duplicate Zod installations:
- `/node_modules/zod` (root)
- `/app/node_modules/zod` (app-local)

The `@asteasolutions/zod-to-openapi` library expects a single Zod instance, causing TypeScript errors like:
```
Property 'openapi' does not exist on type 'ZodString'
```

## Changes

- Remove default `working-directory: app`
- Install deps from root (matches app-ci.yml pattern)
- Add explicit `working-directory: app` to app-specific steps
- Fix cache path (`node_modules` instead of `app/node_modules`)
- Fix lockfile name (`bun.lock` instead of `bun.lockb`)

## Test plan

- [ ] Workflow passes on this branch
- [ ] npm publish succeeds after merge to develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)