### PR TITLE
fix(ci): install dependencies in app directory only

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -38,12 +38,13 @@ jobs:
       - name: Cache dependencies
         uses: actions/cache@v4
         with:
-          path: node_modules
+          path: app/node_modules
           key: bun-${{ hashFiles('**/bun.lock') }}
           restore-keys: |
             bun-
 
       - name: Install dependencies
+        working-directory: app
         run: bun install --frozen-lockfile
 
       - name: Type check application


### PR DESCRIPTION
## Summary

- Fix npm-publish workflow failing with `EUNSUPPORTEDPROTOCOL` error
- Install dependencies only in `app/` directory instead of monorepo root
- Update cache path to `app/node_modules` to match

## Root Cause

The workflow was running `bun install` at root level, which installed all workspace dependencies including `web/` which has `"kotadb": "workspace:*"`. When `npm version` ran later, npm didn't understand the Bun workspace protocol.

## Test plan

- [ ] Merge PR and verify npm-publish workflow succeeds on develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)