### PR TITLE
fix(ci): use Node.js for version update instead of npm

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -38,13 +38,12 @@ jobs:
       - name: Cache dependencies
         uses: actions/cache@v4
         with:
-          path: app/node_modules
-          key: bun-${{ hashFiles('**/bun.lock') }}
+          path: node_modules
+          key: bun-npm-publish-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            bun-
+            bun-npm-publish-
 
       - name: Install dependencies
-        working-directory: app
         run: bun install --frozen-lockfile
 
       - name: Type check application
@@ -89,7 +88,7 @@ jobs:
           TIMESTAMP=$(date +%Y%m%d%H%M%S)
           PRE_VERSION="${CURRENT_VERSION}-next.${TIMESTAMP}"
           echo "Publishing pre-release version: ${PRE_VERSION}"
-          npm version ${PRE_VERSION} --no-git-tag-version
+          node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json'));p.version='${PRE_VERSION}';fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n');"
 
       - name: Publish to npm
         working-directory: app


### PR DESCRIPTION
## Summary

- Install dependencies from root (proper Zod hoisting/deduplication)
- Replace `npm version` with Node.js script (avoids npm parsing lockfile)
- Update cache key to use unique prefix and only root bun.lock

## Root Cause

Two conflicting issues:

| Approach | Zod Resolution | Version Update |
|----------|----------------|----------------|
| Install from `app/` | ❌ Conflict (duplicate Zod) | ✅ Works |
| Install from root | ✅ Proper hoisting | ❌ `npm version` fails on `workspace:*` |

## Solution

Install from root for proper dependency resolution, but use Node.js to update version directly instead of `npm version`. The Node.js script edits package.json without invoking npm, avoiding the `EUNSUPPORTEDPROTOCOL` error.

## Test plan

- [ ] Merge PR and verify npm-publish workflow succeeds on develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)