### PR TITLE
fix(ci): use npm publish instead of bun publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -23,6 +23,12 @@ jobs:
         with:
           bun-version: 1.1.29
 
+      - name: Setup Node.js for npm publish
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
       - name: Verify tag matches package version
         if: startsWith(github.ref, 'refs/tags/')
         working-directory: app
@@ -95,10 +101,10 @@ jobs:
         run: |
           if [ "${{ github.ref }}" = "refs/heads/develop" ]; then
             echo "Publishing to 'next' tag..."
-            bun publish --access public --tag next
+            npm publish --access public --tag next
           else
             echo "Publishing to 'latest' tag..."
-            bun publish --access public
+            npm publish --access public
           fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Fixes the persistently failing "Publish to npm" CI workflow on develop.

**Root Cause:** The workflow was using `bun publish` which is not a valid Bun command. Bun reserves this command for future use and fails with:
```
Uh-oh. bun publish is a subcommand reserved for future use by Bun.
If you were trying to run a package.json script called publish, use bun run publish.
```

**Fix:**
- Added `actions/setup-node@v4` with `registry-url` to configure npm authentication
- Changed `bun publish` → `npm publish` (Bun is still used for install/test/build)

## Previous Fix Attempts

| PR | Approach | Result |
|----|----------|--------|
| #41 | Resolve Zod version conflict | Failed - didn't fix publish command |
| #42 | Install deps in app directory | Failed - didn't fix publish command |
| #43 | Use Node.js for version update | Failed - didn't fix publish command |

All previous attempts missed the actual issue: `bun publish` is not a valid command.

## Test plan

- [ ] CI workflow passes on this PR
- [ ] Merge to develop triggers successful npm publish
- [ ] Package appears at https://npmjs.com/package/kotadb with @next tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)