### PR TITLE
fix(ci): use npm Trusted Publishers (OIDC) for authentication

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,6 +11,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Checkout repository
@@ -101,13 +104,11 @@ jobs:
         run: |
           if [ "${{ github.ref }}" = "refs/heads/develop" ]; then
             echo "Publishing to 'next' tag..."
-            npm publish --access public --tag next
+            npm publish --access public --tag next --provenance
           else
             echo "Publishing to 'latest' tag..."
-            npm publish --access public
+            npm publish --access public --provenance
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub Release
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
## Summary

Switches npm publishing from token-based auth to OIDC-based Trusted Publishers.

**Problem:** The NPM_TOKEN was returning 403 Forbidden errors. Rather than debug the token, switching to npm's recommended Trusted Publishers approach.

**Changes:**
- Add `id-token: write` permission for OIDC token request
- Add `--provenance` flag to npm publish commands
- Remove `NPM_TOKEN` env var (OIDC handles auth automatically)

## Why Trusted Publishers?

- **More secure**: No long-lived secrets to manage
- **npm recommended**: This is npm's preferred approach
- **Provenance**: Packages get cryptographic attestation linking them to the source repo

## Prerequisites

The Trusted Publisher must be configured on npmjs.com:
- Package: `kotadb`
- Repository: `jayminwest/kotadb`
- Workflow: `npm-publish.yml`

## Test plan

- [ ] Merge triggers npm publish workflow
- [ ] Workflow successfully publishes to npm with provenance
- [ ] Package visible at https://npmjs.com/package/kotadb with @next tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)