### PR TITLE
fix(ci): upgrade to Node.js 24 for npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js for npm publish
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Verify tag matches package version


### PR DESCRIPTION
## Summary

Fixes npm Trusted Publishers failing with 404/auth errors.

## Root Cause

npm Trusted Publishers with OIDC **requires npm >= 11.5.1**:

| Node.js Version | Bundled npm | OIDC Support |
|-----------------|-------------|--------------|
| Node.js 20 | npm 9.x/10.x | ❌ Too old |
| Node.js 24 | npm 11.5.1+ | ✅ Required |

The workflow was using Node.js 20, which doesn't have a new enough npm to support OIDC authentication.

## Fix

Change `node-version: '20'` → `node-version: '24'`

## Research Sources

- [npm Trusted Publishing Docs](https://docs.npmjs.com/trusted-publishers/)
- [How to set up trusted publishing for npm](https://remarkablemark.org/blog/2025/12/19/npm-trusted-publishing/) - States npm >=11.5.1 or Node.js >=24 required
- [npm trusted publishing with OIDC - GitHub Changelog](https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/)

## Test plan

- [ ] Merge triggers npm publish workflow  
- [ ] npm authenticates via OIDC (no token needed)
- [ ] Package publishes to https://npmjs.com/package/kotadb with @next tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)