### PR TITLE
feat(agents): add KotaDB MCP tools to expert domain agents for dogfooding

### DIFF
--- a/.claude/agents/agent-registry.json
+++ b/.claude/agents/agent-registry.json
@@ -20,9 +20,9 @@
         "Grep",
         "Read",
         "Task",
-        "mcp__kotadb__search_code",
-        "mcp__kotadb__search_dependencies",
-        "mcp__kotadb__list_recent_files"
+        "mcp__kotadb-bunx__search_code",
+        "mcp__kotadb-bunx__search_dependencies",
+        "mcp__kotadb-bunx__list_recent_files"
       ],
       "readOnly": true
     },
@@ -48,9 +48,9 @@
         "NotebookEdit",
         "Task",
         "TodoWrite",
-        "mcp__kotadb__search_code",
-        "mcp__kotadb__search_dependencies",
-        "mcp__kotadb__analyze_change_impact"
+        "mcp__kotadb-bunx__search_code",
+        "mcp__kotadb-bunx__search_dependencies",
+        "mcp__kotadb-bunx__analyze_change_impact"
       ],
       "readOnly": false
     },
@@ -71,9 +71,9 @@
         "Grep",
         "Read",
         "Task",
-        "mcp__kotadb__search_code",
-        "mcp__kotadb__search_dependencies",
-        "mcp__kotadb__analyze_change_impact",
+        "mcp__kotadb-bunx__search_code",
+        "mcp__kotadb-bunx__search_dependencies",
+        "mcp__kotadb-bunx__analyze_change_impact",
         "WebFetch"
       ],
       "readOnly": true
@@ -109,7 +109,10 @@
         "Read",
         "Glob",
         "Grep",
-        "Write"
+        "Write",
+        "mcp__kotadb-bunx__search_code",
+        "mcp__kotadb-bunx__search_dependencies",
+        "mcp__kotadb-bunx__list_recent_files"
       ],
       "readOnly": false
     },
@@ -126,7 +129,10 @@
         "Write",
         "Edit",
         "Glob",
-        "Grep"
+        "Grep",
+        "mcp__kotadb-bunx__search_code",
+        "mcp__kotadb-bunx__search_dependencies",
+        "mcp__kotadb-bunx__analyze_change_impact"
       ],
       "readOnly": false
     },
@@ -144,7 +150,9 @@
         "Edit",
         "Glob",
         "Grep",
-        "Bash"
+        "Bash",
+        "mcp__kotadb-bunx__search_code",
+        "mcp__kotadb-bunx__search_dependencies"
       ],
       "readOnly": false
     },
@@ -159,7 +167,10 @@
       "tools": [
         "Read",
         "Glob",
-        "Grep"
+        "Grep",
+        "mcp__kotadb-bunx__search_code",
+        "mcp__kotadb-bunx__search_dependencies",
+        "mcp__kotadb-bunx__list_recent_files"
       ],
       "readOnly": true
     },
@@ -176,7 +187,10 @@
         "Read",
         "Glob",
         "Grep",
-        "Write"
+        "Write",
+        "mcp__kotadb-bunx__search_code",
+        "mcp__kotadb-bunx__search_dependencies",
+        "mcp__kotadb-bunx__list_recent_files"
       ],
       "readOnly": false
     },
@@ -193,7 +207,10 @@
         "Write",
         "Edit",
         "Glob",
-        "Grep"
+        "Grep",
+        "mcp__kotadb-bunx__search_code",
+        "mcp__kotadb-bunx__search_dependencies",
+        "mcp__kotadb-bunx__analyze_change_impact"
       ],
       "readOnly": false
     },
@@ -211,7 +228,9 @@
         "Edit",
         "Glob",
         "Grep",
-        "Bash"
+        "Bash",
+        "mcp__kotadb-bunx__search_code",
+        "mcp__kotadb-bunx__search_dependencies"
       ],
       "readOnly": false
     },
@@ -226,7 +245,10 @@
       "tools": [
         "Read",
         "Glob",
-        "Grep"
+        "Grep",
+        "mcp__kotadb-bunx__search_code",
+        "mcp__kotadb-bunx__search_dependencies",
+        "mcp__kotadb-bunx__list_recent_files"
       ],
       "readOnly": true
     },
@@ -243,7 +265,10 @@
         "Read",
         "Glob",
         "Grep",
-        "Write"
+        "Write",
+        "mcp__kotadb-bunx__search_code",
+        "mcp__kotadb-bunx__search_dependencies",
+        "mcp__kotadb-bunx__list_recent_files"
       ],
       "readOnly": false
     },
@@ -260,7 +285,10 @@
         "Write",
         "Edit",
         "Glob",
-        "Grep"
+        "Grep",
+        "mcp__kotadb-bunx__search_code",
+        "mcp__kotadb-bunx__search_dependencies",
+        "mcp__kotadb-bunx__analyze_change_impact"
       ],
       "readOnly": false
     },
@@ -278,7 +306,9 @@
         "Edit",
         "Glob",
         "Grep",
-        "Bash"
+        "Bash",
+        "mcp__kotadb-bunx__search_code",
+        "mcp__kotadb-bunx__search_dependencies"
       ],
       "readOnly": false
     },
@@ -293,7 +323,10 @@
       "tools": [
         "Read",
         "Glob",
-        "Grep"
+        "Grep",
+        "mcp__kotadb-bunx__search_code",
+        "mcp__kotadb-bunx__search_dependencies",
+        "mcp__kotadb-bunx__list_recent_files"
       ],
       "readOnly": true
     },
@@ -310,7 +343,10 @@
         "Read",
         "Glob",
         "Grep",
-        "Write"
+        "Write",
+        "mcp__kotadb-bunx__search_code",
+        "mcp__kotadb-bunx__search_dependencies",
+        "mcp__kotadb-bunx__list_recent_files"
       ],
       "readOnly": false
     },
@@ -327,7 +363,10 @@
         "Write",
         "Edit",
         "Glob",
-        "Grep"
+        "Grep",
+        "mcp__kotadb-bunx__search_code",
+        "mcp__kotadb-bunx__search_dependencies",
+        "mcp__kotadb-bunx__analyze_change_impact"
       ],
       "readOnly": false
     },
@@ -345,7 +384,9 @@
         "Edit",
         "Glob",
         "Grep",
-        "Bash"
+        "Bash",
+        "mcp__kotadb-bunx__search_code",
+        "mcp__kotadb-bunx__search_dependencies"
       ],
       "readOnly": false
     },
@@ -360,7 +401,10 @@
       "tools": [
         "Read",
         "Glob",
-        "Grep"
+        "Grep",
+        "mcp__kotadb-bunx__search_code",
+        "mcp__kotadb-bunx__search_dependencies",
+        "mcp__kotadb-bunx__list_recent_files"
       ],
       "readOnly": true
     },
@@ -378,7 +422,10 @@
         "Read",
         "Glob",
         "Grep",
-        "Write"
+        "Write",
+        "mcp__kotadb-bunx__search_code",
+        "mcp__kotadb-bunx__search_dependencies",
+        "mcp__kotadb-bunx__list_recent_files"
       ],
       "readOnly": false
     },
@@ -397,7 +444,10 @@
         "Write",
         "Edit",
         "Glob",
-        "Grep"
+        "Grep",
+        "mcp__kotadb-bunx__search_code",
+        "mcp__kotadb-bunx__search_dependencies",
+        "mcp__kotadb-bunx__analyze_change_impact"
       ],
       "readOnly": false
     },
@@ -415,7 +465,9 @@
         "Edit",
         "Glob",
         "Grep",
-        "Bash"
+        "Bash",
+        "mcp__kotadb-bunx__search_code",
+        "mcp__kotadb-bunx__search_dependencies"
       ],
       "readOnly": false
     },
@@ -430,7 +482,10 @@
       "tools": [
         "Read",
         "Glob",
-        "Grep"
+        "Grep",
+        "mcp__kotadb-bunx__search_code",
+        "mcp__kotadb-bunx__search_dependencies",
+        "mcp__kotadb-bunx__list_recent_files"
       ],
       "readOnly": true
     },
@@ -447,7 +502,10 @@
         "Read",
         "Glob",
         "Grep",
-        "Write"
+        "Write",
+        "mcp__kotadb-bunx__search_code",
+        "mcp__kotadb-bunx__search_dependencies",
+        "mcp__kotadb-bunx__list_recent_files"
       ],
       "readOnly": false
     },
@@ -464,7 +522,10 @@
         "Write",
         "Edit",
         "Glob",
-        "Grep"
+        "Grep",
+        "mcp__kotadb-bunx__search_code",
+        "mcp__kotadb-bunx__search_dependencies",
+        "mcp__kotadb-bunx__analyze_change_impact"
       ],
       "readOnly": false
     },
@@ -482,7 +543,9 @@
         "Edit",
         "Glob",
         "Grep",
-        "Bash"
+        "Bash",
+        "mcp__kotadb-bunx__search_code",
+        "mcp__kotadb-bunx__search_dependencies"
       ],
       "readOnly": false
     },
@@ -497,7 +560,91 @@
       "tools": [
         "Read",
         "Glob",
-        "Grep"
+        "Grep",
+        "mcp__kotadb-bunx__search_code",
+        "mcp__kotadb-bunx__search_dependencies",
+        "mcp__kotadb-bunx__list_recent_files"
+      ],
+      "readOnly": true
+    },
+    "github-plan-agent": {
+      "name": "github-plan-agent",
+      "description": "Plans GitHub workflow tasks for kotadb. Expects USER_PROMPT (requirement)",
+      "file": "experts/github/github-plan-agent.md",
+      "model": "sonnet",
+      "capabilities": [
+        "github-planning",
+        "spec-generation"
+      ],
+      "tools": [
+        "Read",
+        "Glob",
+        "Grep",
+        "Write",
+        "Bash",
+        "mcp__kotadb-bunx__search_code",
+        "mcp__kotadb-bunx__search_dependencies",
+        "mcp__kotadb-bunx__list_recent_files"
+      ],
+      "readOnly": false
+    },
+    "github-build-agent": {
+      "name": "github-build-agent",
+      "description": "Implements GitHub workflows from specs. Expects SPEC (path to spec file)",
+      "file": "experts/github/github-build-agent.md",
+      "model": "sonnet",
+      "capabilities": [
+        "github-implementation"
+      ],
+      "tools": [
+        "Read",
+        "Write",
+        "Edit",
+        "Glob",
+        "Grep",
+        "Bash",
+        "mcp__kotadb-bunx__search_code",
+        "mcp__kotadb-bunx__search_dependencies",
+        "mcp__kotadb-bunx__analyze_change_impact"
+      ],
+      "readOnly": false
+    },
+    "github-improve-agent": {
+      "name": "github-improve-agent",
+      "description": "Updates github expertise from workflow changes. Expects CHANGE_SUMMARY",
+      "file": "experts/github/github-improve-agent.md",
+      "model": "sonnet",
+      "capabilities": [
+        "github-expertise-evolution"
+      ],
+      "tools": [
+        "Read",
+        "Write",
+        "Edit",
+        "Glob",
+        "Grep",
+        "Bash",
+        "Task",
+        "mcp__kotadb-bunx__search_code",
+        "mcp__kotadb-bunx__search_dependencies"
+      ],
+      "readOnly": false
+    },
+    "github-question-agent": {
+      "name": "github-question-agent",
+      "description": "Answers GitHub workflow questions. Expects QUESTION (user query)",
+      "file": "experts/github/github-question-agent.md",
+      "model": "haiku",
+      "capabilities": [
+        "github-qa"
+      ],
+      "tools": [
+        "Read",
+        "Glob",
+        "Grep",
+        "mcp__kotadb-bunx__search_code",
+        "mcp__kotadb-bunx__search_dependencies",
+        "mcp__kotadb-bunx__list_recent_files"
       ],
       "readOnly": true
     }
@@ -609,7 +756,8 @@
       "api-plan-agent",
       "indexer-plan-agent",
       "database-plan-agent",
-      "testing-plan-agent"
+      "testing-plan-agent",
+      "github-plan-agent"
     ],
     "database-planning": [
       "database-plan-agent"
@@ -643,6 +791,18 @@
     ],
     "testing-qa": [
       "testing-question-agent"
+    ],
+    "github-planning": [
+      "github-plan-agent"
+    ],
+    "github-implementation": [
+      "github-build-agent"
+    ],
+    "github-expertise-evolution": [
+      "github-improve-agent"
+    ],
+    "github-qa": [
+      "github-question-agent"
     ]
   },
   "modelIndex": {
@@ -654,7 +814,8 @@
       "api-question-agent",
       "indexer-question-agent",
       "database-question-agent",
-      "testing-question-agent"
+      "testing-question-agent",
+      "github-question-agent"
     ],
     "sonnet": [
       "build-agent",
@@ -676,151 +837,175 @@
       "database-improve-agent",
       "testing-plan-agent",
       "testing-build-agent",
-      "testing-improve-agent"
+      "testing-improve-agent",
+      "github-plan-agent",
+      "github-build-agent",
+      "github-improve-agent"
     ]
   },
   "toolMatrix": {
     "Glob": [
-      "scout-agent",
-      "build-agent",
-      "review-agent",
-      "claude-config-plan-agent",
-      "claude-config-build-agent",
-      "claude-config-improve-agent",
-      "claude-config-question-agent",
-      "agent-authoring-plan-agent",
       "agent-authoring-build-agent",
       "agent-authoring-improve-agent",
+      "agent-authoring-plan-agent",
       "agent-authoring-question-agent",
-      "api-plan-agent",
       "api-build-agent",
       "api-improve-agent",
+      "api-plan-agent",
       "api-question-agent",
-      "indexer-plan-agent",
-      "indexer-build-agent",
-      "indexer-improve-agent",
-      "indexer-question-agent",
-      "database-plan-agent",
+      "build-agent",
+      "claude-config-build-agent",
+      "claude-config-improve-agent",
+      "claude-config-plan-agent",
+      "claude-config-question-agent",
       "database-build-agent",
       "database-improve-agent",
+      "database-plan-agent",
       "database-question-agent",
-      "testing-plan-agent",
+      "github-build-agent",
+      "github-improve-agent",
+      "github-plan-agent",
+      "github-question-agent",
+      "indexer-build-agent",
+      "indexer-improve-agent",
+      "indexer-plan-agent",
+      "indexer-question-agent",
+      "review-agent",
+      "scout-agent",
       "testing-build-agent",
       "testing-improve-agent",
+      "testing-plan-agent",
       "testing-question-agent"
     ],
     "Grep": [
-      "scout-agent",
-      "build-agent",
-      "review-agent",
-      "claude-config-plan-agent",
-      "claude-config-build-agent",
-      "claude-config-improve-agent",
-      "claude-config-question-agent",
-      "agent-authoring-plan-agent",
       "agent-authoring-build-agent",
       "agent-authoring-improve-agent",
+      "agent-authoring-plan-agent",
       "agent-authoring-question-agent",
-      "api-plan-agent",
       "api-build-agent",
       "api-improve-agent",
+      "api-plan-agent",
       "api-question-agent",
-      "indexer-plan-agent",
-      "indexer-build-agent",
-      "indexer-improve-agent",
-      "indexer-question-agent",
-      "database-plan-agent",
+      "build-agent",
+      "claude-config-build-agent",
+      "claude-config-improve-agent",
+      "claude-config-plan-agent",
+      "claude-config-question-agent",
       "database-build-agent",
       "database-improve-agent",
+      "database-plan-agent",
       "database-question-agent",
-      "testing-plan-agent",
+      "github-build-agent",
+      "github-improve-agent",
+      "github-plan-agent",
+      "github-question-agent",
+      "indexer-build-agent",
+      "indexer-improve-agent",
+      "indexer-plan-agent",
+      "indexer-question-agent",
+      "review-agent",
+      "scout-agent",
       "testing-build-agent",
       "testing-improve-agent",
+      "testing-plan-agent",
       "testing-question-agent"
     ],
     "Read": [
-      "scout-agent",
-      "build-agent",
-      "review-agent",
-      "claude-config-plan-agent",
-      "claude-config-build-agent",
-      "claude-config-improve-agent",
-      "claude-config-question-agent",
-      "agent-authoring-plan-agent",
       "agent-authoring-build-agent",
       "agent-authoring-improve-agent",
+      "agent-authoring-plan-agent",
       "agent-authoring-question-agent",
-      "api-plan-agent",
       "api-build-agent",
       "api-improve-agent",
+      "api-plan-agent",
       "api-question-agent",
-      "indexer-plan-agent",
-      "indexer-build-agent",
-      "indexer-improve-agent",
-      "indexer-question-agent",
-      "database-plan-agent",
+      "build-agent",
+      "claude-config-build-agent",
+      "claude-config-improve-agent",
+      "claude-config-plan-agent",
+      "claude-config-question-agent",
       "database-build-agent",
       "database-improve-agent",
+      "database-plan-agent",
       "database-question-agent",
-      "testing-plan-agent",
+      "github-build-agent",
+      "github-improve-agent",
+      "github-plan-agent",
+      "github-question-agent",
+      "indexer-build-agent",
+      "indexer-improve-agent",
+      "indexer-plan-agent",
+      "indexer-question-agent",
+      "review-agent",
+      "scout-agent",
       "testing-build-agent",
       "testing-improve-agent",
+      "testing-plan-agent",
       "testing-question-agent"
     ],
     "Edit": [
-      "build-agent",
-      "docs-scraper",
-      "claude-config-build-agent",
-      "claude-config-improve-agent",
       "agent-authoring-build-agent",
       "agent-authoring-improve-agent",
       "api-build-agent",
       "api-improve-agent",
-      "indexer-build-agent",
-      "indexer-improve-agent",
+      "build-agent",
+      "claude-config-build-agent",
+      "claude-config-improve-agent",
       "database-build-agent",
       "database-improve-agent",
+      "docs-scraper",
+      "github-build-agent",
+      "github-improve-agent",
+      "indexer-build-agent",
+      "indexer-improve-agent",
       "testing-build-agent",
       "testing-improve-agent"
     ],
     "Write": [
-      "build-agent",
-      "docs-scraper",
-      "claude-config-plan-agent",
-      "claude-config-build-agent",
-      "claude-config-improve-agent",
-      "agent-authoring-plan-agent",
       "agent-authoring-build-agent",
       "agent-authoring-improve-agent",
-      "api-plan-agent",
+      "agent-authoring-plan-agent",
       "api-build-agent",
       "api-improve-agent",
-      "indexer-plan-agent",
-      "indexer-build-agent",
-      "indexer-improve-agent",
-      "database-plan-agent",
+      "api-plan-agent",
+      "build-agent",
+      "claude-config-build-agent",
+      "claude-config-improve-agent",
+      "claude-config-plan-agent",
       "database-build-agent",
       "database-improve-agent",
-      "testing-plan-agent",
+      "database-plan-agent",
+      "docs-scraper",
+      "github-build-agent",
+      "github-improve-agent",
+      "github-plan-agent",
+      "indexer-build-agent",
+      "indexer-improve-agent",
+      "indexer-plan-agent",
       "testing-build-agent",
-      "testing-improve-agent"
+      "testing-improve-agent",
+      "testing-plan-agent"
     ],
     "Bash": [
-      "build-agent",
-      "claude-config-improve-agent",
       "agent-authoring-improve-agent",
       "api-improve-agent",
-      "indexer-improve-agent",
+      "build-agent",
+      "claude-config-improve-agent",
       "database-improve-agent",
+      "github-build-agent",
+      "github-improve-agent",
+      "github-plan-agent",
+      "indexer-improve-agent",
       "testing-improve-agent"
     ],
     "NotebookEdit": [
       "build-agent"
     ],
     "Task": [
-      "scout-agent",
       "build-agent",
-      "review-agent"
+      "github-improve-agent",
+      "review-agent",
+      "scout-agent"
     ],
     "TodoWrite": [
       "build-agent"
@@ -829,25 +1014,102 @@
       "review-agent",
       "docs-scraper"
     ],
-    "mcp__kotadb__search_code": [
-      "scout-agent",
-      "build-agent",
-      "review-agent"
-    ],
-    "mcp__kotadb__search_dependencies": [
-      "scout-agent",
-      "build-agent",
-      "review-agent"
-    ],
-    "mcp__kotadb__list_recent_files": [
-      "scout-agent"
-    ],
-    "mcp__kotadb__analyze_change_impact": [
-      "build-agent",
-      "review-agent"
-    ],
     "mcp__firecrawl-mcp__firecrawl_scrape": [
       "docs-scraper"
+    ],
+    "mcp__kotadb-bunx__search_code": [
+      "agent-authoring-build-agent",
+      "agent-authoring-improve-agent",
+      "agent-authoring-plan-agent",
+      "agent-authoring-question-agent",
+      "api-build-agent",
+      "api-improve-agent",
+      "api-plan-agent",
+      "api-question-agent",
+      "build-agent",
+      "claude-config-build-agent",
+      "claude-config-improve-agent",
+      "claude-config-plan-agent",
+      "claude-config-question-agent",
+      "database-build-agent",
+      "database-improve-agent",
+      "database-plan-agent",
+      "database-question-agent",
+      "github-build-agent",
+      "github-improve-agent",
+      "github-plan-agent",
+      "github-question-agent",
+      "indexer-build-agent",
+      "indexer-improve-agent",
+      "indexer-plan-agent",
+      "indexer-question-agent",
+      "review-agent",
+      "scout-agent",
+      "testing-build-agent",
+      "testing-improve-agent",
+      "testing-plan-agent",
+      "testing-question-agent"
+    ],
+    "mcp__kotadb-bunx__search_dependencies": [
+      "agent-authoring-build-agent",
+      "agent-authoring-improve-agent",
+      "agent-authoring-plan-agent",
+      "agent-authoring-question-agent",
+      "api-build-agent",
+      "api-improve-agent",
+      "api-plan-agent",
+      "api-question-agent",
+      "build-agent",
+      "claude-config-build-agent",
+      "claude-config-improve-agent",
+      "claude-config-plan-agent",
+      "claude-config-question-agent",
+      "database-build-agent",
+      "database-improve-agent",
+      "database-plan-agent",
+      "database-question-agent",
+      "github-build-agent",
+      "github-improve-agent",
+      "github-plan-agent",
+      "github-question-agent",
+      "indexer-build-agent",
+      "indexer-improve-agent",
+      "indexer-plan-agent",
+      "indexer-question-agent",
+      "review-agent",
+      "scout-agent",
+      "testing-build-agent",
+      "testing-improve-agent",
+      "testing-plan-agent",
+      "testing-question-agent"
+    ],
+    "mcp__kotadb-bunx__list_recent_files": [
+      "agent-authoring-plan-agent",
+      "agent-authoring-question-agent",
+      "api-plan-agent",
+      "api-question-agent",
+      "claude-config-plan-agent",
+      "claude-config-question-agent",
+      "database-plan-agent",
+      "database-question-agent",
+      "github-plan-agent",
+      "github-question-agent",
+      "indexer-plan-agent",
+      "indexer-question-agent",
+      "scout-agent",
+      "testing-plan-agent",
+      "testing-question-agent"
+    ],
+    "mcp__kotadb-bunx__analyze_change_impact": [
+      "agent-authoring-build-agent",
+      "api-build-agent",
+      "build-agent",
+      "claude-config-build-agent",
+      "database-build-agent",
+      "github-build-agent",
+      "indexer-build-agent",
+      "review-agent",
+      "testing-build-agent"
     ]
   }
 }

--- a/.claude/agents/experts/agent-authoring/agent-authoring-build-agent.md
+++ b/.claude/agents/experts/agent-authoring/agent-authoring-build-agent.md
@@ -8,6 +8,9 @@ tools:
   - Glob
   - Grep
   - Bash
+  - mcp__kotadb-bunx__search_code
+  - mcp__kotadb-bunx__search_dependencies
+  - mcp__kotadb-bunx__analyze_change_impact
 model: sonnet
 color: green
 expertDomain: agent-authoring

--- a/.claude/agents/experts/agent-authoring/agent-authoring-improve-agent.md
+++ b/.claude/agents/experts/agent-authoring/agent-authoring-improve-agent.md
@@ -9,6 +9,8 @@ tools:
   - Grep
   - Bash
   - Task
+  - mcp__kotadb-bunx__search_code
+  - mcp__kotadb-bunx__search_dependencies
 model: sonnet
 color: purple
 expertDomain: agent-authoring

--- a/.claude/agents/experts/agent-authoring/agent-authoring-plan-agent.md
+++ b/.claude/agents/experts/agent-authoring/agent-authoring-plan-agent.md
@@ -7,6 +7,9 @@ tools:
   - Grep
   - Write
   - Bash
+  - mcp__kotadb-bunx__search_code
+  - mcp__kotadb-bunx__search_dependencies
+  - mcp__kotadb-bunx__list_recent_files
 model: sonnet
 color: yellow
 expertDomain: agent-authoring
@@ -147,6 +150,9 @@ description: <action verb + domain + context - NO COLONS>
 tools:
   - <Tool1>
   - <Tool2>
+  - mcp__kotadb-bunx__search_code
+  - mcp__kotadb-bunx__search_dependencies
+  - mcp__kotadb-bunx__list_recent_files
 model: <haiku|sonnet|opus>
 constraints:
   - <constraint 1>

--- a/.claude/agents/experts/agent-authoring/agent-authoring-question-agent.md
+++ b/.claude/agents/experts/agent-authoring/agent-authoring-question-agent.md
@@ -5,6 +5,9 @@ tools:
   - Read
   - Glob
   - Grep
+  - mcp__kotadb-bunx__search_code
+  - mcp__kotadb-bunx__search_dependencies
+  - mcp__kotadb-bunx__list_recent_files
 model: haiku
 color: cyan
 expertDomain: agent-authoring

--- a/.claude/agents/experts/agent-authoring/expertise.yaml
+++ b/.claude/agents/experts/agent-authoring/expertise.yaml
@@ -443,20 +443,38 @@ patterns:
         cost: Registry must be kept in sync with agent files
 
   mcp_tool_patterns:
-    name: MCP Tool Selection Patterns
+    name: MCP Tool Selection Patterns (kotadb naming convention)
     context: kotadb uses MCP tools for codebase search and analysis
     implementation: |
+      **MCP Tool Naming Convention** [2026-01-29]:
+      Format: mcp__{SERVER_NAME}__toolName
+      
+      The server name comes from .mcp.json mcpServers key.
+      Current .mcp.json: "kotadb-bunx" (bunx stdio transport, commit 30173e6)
+      Therefore tool prefix MUST be: mcp__kotadb-bunx__
+      
+      Do NOT use: mcp__kotadb__ (deprecated old prefix from HTTP era)
+      Use instead: mcp__kotadb-bunx__ (current standard, expert agents updated)
+      
+      Status as of 2026-01-29:
+      - Expert agents (80+ refs): Updated to mcp__kotadb-bunx__ ✓
+      - agent-registry.json: Updated to mcp__kotadb-bunx__ ✓
+      - General agents: Still use mcp__kotadb__ (scout, build, review - pending)
+      
       KotaDB MCP tools (search and analysis):
-      - mcp__kotadb__search_code(term)
-      - mcp__kotadb__search_dependencies(file_path, direction, depth)
-      - mcp__kotadb__analyze_change_impact(files)
-      - mcp__kotadb__list_recent_files()
+      - mcp__kotadb-bunx__search_code(term) - Semantic code search
+      - mcp__kotadb-bunx__search_dependencies(file_path, direction, depth) - Dependency graph
+      - mcp__kotadb-bunx__analyze_change_impact(files) - Change impact assessment
+      - mcp__kotadb-bunx__list_recent_files() - Recent file discovery
 
-      Tool selection by agent type:
-      - scout-agent: Optional kotadb search tools
-      - build-agent: kotadb search_dependencies, analyze_change_impact
-      - expert agents: kotadb tools as needed for domain
-
+      Tool assignment patterns by agent type:
+      - scout-agent: search_code, search_dependencies, list_recent_files (read-only)
+      - build-agent: search_code, search_dependencies, analyze_change_impact (implementation)
+      - review-agent: search_code, search_dependencies, analyze_change_impact (analysis)
+      - expert plan agents: search_code, search_dependencies, list_recent_files
+      - expert build agents: search_code, search_dependencies, analyze_change_impact
+      - expert improve agents: search_code, search_dependencies (sub-agent analysis)
+      - expert question agents: search_code, search_dependencies, list_recent_files
   permissive_tools_strict_prompts:
     name: Permissive Tools + Strict Prompts Pattern
     context: Tool permission philosophy discovered 2026-01-28
@@ -539,6 +557,13 @@ best_practices:
         evidence: All updated agents include "Use Bash for..." or "Use Task to..." guidance after Output Style
         timestamp: 2026-01-28
 
+      - practice: MCP tool prefix derives from .mcp.json server name
+        evidence: Server "kotadb-bunx" -> tools must use "mcp__kotadb-bunx__" prefix (commit 30173e6)
+        timestamp: 2026-01-29
+      - practice: Keep agent files and registry in sync for MCP tool names
+        evidence: Expert agents (80+ refs) updated to mcp__kotadb-bunx__; registry updated; general agents pending
+        timestamp: 2026-01-29
+
   - category: Naming
     practices:
       - practice: General agents use descriptive kebab-case naming
@@ -577,6 +602,12 @@ best_practices:
       - practice: Maintain capabilityIndex, modelIndex, and toolMatrix consistency
         evidence: Registry v2.0.0 has complete indexes for all 27+ agents
         timestamp: 2026-01-28
+      - practice: MCP tool prefixes in registry must match .mcp.json server names
+        evidence: Expert agents and registry updated to use mcp__kotadb-bunx__ (2026-01-29)
+        timestamp: 2026-01-29
+      - practice: Update agent-registry.json toolMatrix when changing MCP tool prefixes
+        evidence: Registry toolMatrix updated alongside agent frontmatter changes
+        timestamp: 2026-01-29
 
   - category: Expert Domain Organization
     practices:
@@ -610,17 +641,6 @@ potential_enhancements:
     timestamp: 2026-01-28
 
 recent_changes:
-  - change: Removed branch/leaf hierarchy (commit d669841)
-    impact: Major architectural shift to flat structure
-    learnings: |
-      - Branch agents (branch-plan, branch-build, branch-review, branch-meta) removed
-      - Leaf agents (leaf-retrieval, leaf-build, leaf-review) removed
-      - mcp__leaf_spawner__ tools no longer used
-      - Simplified to general agents + experts/ domains
-      - No more branch coordinator pattern
-      - Orchestration now handled at /do command level
-    timestamp: 2026-01-28
-
   - change: Added 5 new expert domains (commits 902c49a, d669841)
     impact: Expanded from 2 to 7 expert domains
     learnings: |
@@ -632,19 +652,29 @@ recent_changes:
       - Registry v2.0.0 with 40+ domain-specific capabilities
     timestamp: 2026-01-28
 
-  - change: Tool permission updates across 19 expert agents (uncommitted 2026-01-28)
+  - change: Tool permission updates across expert agents (2026-01-28)
     impact: "Permissive tools + strict prompts" philosophy implementation
     learnings: |
-      - 6 plan agents gained Bash (agent-authoring, claude-config, database, api, github, indexer)
-      - 6 build agents gained Bash (same domains)
-      - 7 improve agents gained Task (same domains + testing)
-      - Testing domain already had correct permissions (served as model)
-      - One-liner prompt guidance added: "Use Bash for..." or "Use Task to..."
-      - Tool additions enable verification workflows without reconfiguration
-      - Pattern: Give agents tools they might need, guide via instructions
-      - No special permission sections needed - one-liner sufficient
-      - Philosophy shift: from restrictive to permissive with clear guidance
+      - 6 plan agents gained Bash for git/verification operations
+      - 6 build agents gained Bash for type-checking and tests
+      - 7 improve agents gained Task for sub-agent spawning
+      - One-liner prompt guidance ensures appropriate tool usage
+      - Philosophy: Give tools that might be needed, guide via instructions
     timestamp: 2026-01-28
+
+  - change: MCP tool naming convention established and partial migration (2026-01-29)
+    impact: Tools must use prefix derived from .mcp.json server name
+    learnings: |
+      - MCP tool prefix format: mcp__{serverName}__toolName
+      - Server name "kotadb-bunx" from .mcp.json (stdio transport, commit 30173e6)
+      - Tool prefix must be: mcp__kotadb-bunx__
+      - Expert agents (80+ refs) updated to use mcp__kotadb-bunx__ ✓
+      - agent-registry.json updated to use mcp__kotadb-bunx__ ✓
+      - General agents still use mcp__kotadb__ (scout, build, review - deprecated prefix)
+      - Registry toolMatrix must stay in sync with agent frontmatter tools
+      - Convention: Always derive prefix from active .mcp.json configuration
+      - Pattern applies to all MCP servers (kotadb, firecrawl, etc.)
+    timestamp: 2026-01-29
 
 stability:
   convergence_indicators:
@@ -662,4 +692,6 @@ stability:
       - Registry v2.0.0 with comprehensive indexes
       - Removed branch/leaf references completely
       - Removed Supabase references (now SQLite only)
-      - MCP tools limited to mcp__kotadb__* for local search
+      - MCP tool naming convention established (mcp__kotadb-bunx__ from .mcp.json)
+      - Expert agents updated to mcp__kotadb-bunx__, general agents pending migration
+      - Registry toolMatrix kept in sync with agent frontmatter

--- a/.claude/agents/experts/api/api-build-agent.md
+++ b/.claude/agents/experts/api/api-build-agent.md
@@ -8,6 +8,9 @@ tools:
   - Glob
   - Grep
   - Bash
+  - mcp__kotadb-bunx__search_code
+  - mcp__kotadb-bunx__search_dependencies
+  - mcp__kotadb-bunx__analyze_change_impact
 model: sonnet
 color: green
 ---

--- a/.claude/agents/experts/api/api-improve-agent.md
+++ b/.claude/agents/experts/api/api-improve-agent.md
@@ -9,6 +9,8 @@ tools:
   - Grep
   - Bash
   - Task
+  - mcp__kotadb-bunx__search_code
+  - mcp__kotadb-bunx__search_dependencies
 model: sonnet
 color: purple
 ---

--- a/.claude/agents/experts/api/api-plan-agent.md
+++ b/.claude/agents/experts/api/api-plan-agent.md
@@ -7,6 +7,9 @@ tools:
   - Grep
   - Write
   - Bash
+  - mcp__kotadb-bunx__search_code
+  - mcp__kotadb-bunx__search_dependencies
+  - mcp__kotadb-bunx__list_recent_files
 model: sonnet
 color: yellow
 ---

--- a/.claude/agents/experts/api/api-question-agent.md
+++ b/.claude/agents/experts/api/api-question-agent.md
@@ -5,6 +5,9 @@ tools:
   - Read
   - Glob
   - Grep
+  - mcp__kotadb-bunx__search_code
+  - mcp__kotadb-bunx__search_dependencies
+  - mcp__kotadb-bunx__list_recent_files
 model: haiku
 color: cyan
 readOnly: true

--- a/.claude/agents/experts/claude-config/claude-config-build-agent.md
+++ b/.claude/agents/experts/claude-config/claude-config-build-agent.md
@@ -8,6 +8,9 @@ tools:
   - Glob
   - Grep
   - Bash
+  - mcp__kotadb-bunx__search_code
+  - mcp__kotadb-bunx__search_dependencies
+  - mcp__kotadb-bunx__analyze_change_impact
 model: sonnet
 color: green
 ---

--- a/.claude/agents/experts/claude-config/claude-config-improve-agent.md
+++ b/.claude/agents/experts/claude-config/claude-config-improve-agent.md
@@ -9,6 +9,8 @@ tools:
   - Grep
   - Bash
   - Task
+  - mcp__kotadb-bunx__search_code
+  - mcp__kotadb-bunx__search_dependencies
 model: sonnet
 color: purple
 ---

--- a/.claude/agents/experts/claude-config/claude-config-plan-agent.md
+++ b/.claude/agents/experts/claude-config/claude-config-plan-agent.md
@@ -7,6 +7,9 @@ tools:
   - Grep
   - Write
   - Bash
+  - mcp__kotadb-bunx__search_code
+  - mcp__kotadb-bunx__search_dependencies
+  - mcp__kotadb-bunx__list_recent_files
 model: sonnet
 color: yellow
 ---

--- a/.claude/agents/experts/claude-config/claude-config-question-agent.md
+++ b/.claude/agents/experts/claude-config/claude-config-question-agent.md
@@ -5,6 +5,9 @@ tools:
   - Read
   - Glob
   - Grep
+  - mcp__kotadb-bunx__search_code
+  - mcp__kotadb-bunx__search_dependencies
+  - mcp__kotadb-bunx__list_recent_files
 model: haiku
 color: cyan
 ---

--- a/.claude/agents/experts/database/database-build-agent.md
+++ b/.claude/agents/experts/database/database-build-agent.md
@@ -8,6 +8,9 @@ tools:
   - Glob
   - Grep
   - Bash
+  - mcp__kotadb-bunx__search_code
+  - mcp__kotadb-bunx__search_dependencies
+  - mcp__kotadb-bunx__analyze_change_impact
 model: sonnet
 color: green
 ---

--- a/.claude/agents/experts/database/database-improve-agent.md
+++ b/.claude/agents/experts/database/database-improve-agent.md
@@ -9,6 +9,8 @@ tools:
   - Grep
   - Bash
   - Task
+  - mcp__kotadb-bunx__search_code
+  - mcp__kotadb-bunx__search_dependencies
 model: sonnet
 color: purple
 ---

--- a/.claude/agents/experts/database/database-plan-agent.md
+++ b/.claude/agents/experts/database/database-plan-agent.md
@@ -7,6 +7,9 @@ tools:
   - Grep
   - Write
   - Bash
+  - mcp__kotadb-bunx__search_code
+  - mcp__kotadb-bunx__search_dependencies
+  - mcp__kotadb-bunx__list_recent_files
 model: sonnet
 color: yellow
 ---

--- a/.claude/agents/experts/database/database-question-agent.md
+++ b/.claude/agents/experts/database/database-question-agent.md
@@ -5,6 +5,9 @@ tools:
   - Read
   - Glob
   - Grep
+  - mcp__kotadb-bunx__search_code
+  - mcp__kotadb-bunx__search_dependencies
+  - mcp__kotadb-bunx__list_recent_files
 model: haiku
 color: cyan
 readOnly: true

--- a/.claude/agents/experts/github/github-build-agent.md
+++ b/.claude/agents/experts/github/github-build-agent.md
@@ -8,6 +8,9 @@ tools:
   - Glob
   - Grep
   - Bash
+  - mcp__kotadb-bunx__search_code
+  - mcp__kotadb-bunx__search_dependencies
+  - mcp__kotadb-bunx__analyze_change_impact
 model: sonnet
 color: green
 ---

--- a/.claude/agents/experts/github/github-improve-agent.md
+++ b/.claude/agents/experts/github/github-improve-agent.md
@@ -9,6 +9,8 @@ tools:
   - Grep
   - Bash
   - Task
+  - mcp__kotadb-bunx__search_code
+  - mcp__kotadb-bunx__search_dependencies
 model: sonnet
 color: purple
 ---

--- a/.claude/agents/experts/github/github-plan-agent.md
+++ b/.claude/agents/experts/github/github-plan-agent.md
@@ -7,6 +7,9 @@ tools:
   - Grep
   - Write
   - Bash
+  - mcp__kotadb-bunx__search_code
+  - mcp__kotadb-bunx__search_dependencies
+  - mcp__kotadb-bunx__list_recent_files
 model: sonnet
 color: yellow
 ---

--- a/.claude/agents/experts/github/github-question-agent.md
+++ b/.claude/agents/experts/github/github-question-agent.md
@@ -5,6 +5,9 @@ tools:
   - Read
   - Glob
   - Grep
+  - mcp__kotadb-bunx__search_code
+  - mcp__kotadb-bunx__search_dependencies
+  - mcp__kotadb-bunx__list_recent_files
 model: haiku
 color: cyan
 readOnly: true

--- a/.claude/agents/experts/indexer/indexer-build-agent.md
+++ b/.claude/agents/experts/indexer/indexer-build-agent.md
@@ -8,6 +8,9 @@ tools:
   - Glob
   - Grep
   - Bash
+  - mcp__kotadb-bunx__search_code
+  - mcp__kotadb-bunx__search_dependencies
+  - mcp__kotadb-bunx__analyze_change_impact
 model: sonnet
 color: green
 ---

--- a/.claude/agents/experts/indexer/indexer-improve-agent.md
+++ b/.claude/agents/experts/indexer/indexer-improve-agent.md
@@ -9,6 +9,8 @@ tools:
   - Grep
   - Bash
   - Task
+  - mcp__kotadb-bunx__search_code
+  - mcp__kotadb-bunx__search_dependencies
 model: sonnet
 color: purple
 ---

--- a/.claude/agents/experts/indexer/indexer-plan-agent.md
+++ b/.claude/agents/experts/indexer/indexer-plan-agent.md
@@ -7,6 +7,9 @@ tools:
   - Grep
   - Write
   - Bash
+  - mcp__kotadb-bunx__search_code
+  - mcp__kotadb-bunx__search_dependencies
+  - mcp__kotadb-bunx__list_recent_files
 model: sonnet
 color: yellow
 ---

--- a/.claude/agents/experts/indexer/indexer-question-agent.md
+++ b/.claude/agents/experts/indexer/indexer-question-agent.md
@@ -5,6 +5,9 @@ tools:
   - Read
   - Glob
   - Grep
+  - mcp__kotadb-bunx__search_code
+  - mcp__kotadb-bunx__search_dependencies
+  - mcp__kotadb-bunx__list_recent_files
 model: haiku
 color: cyan
 readOnly: true

--- a/.claude/agents/experts/testing/testing-build-agent.md
+++ b/.claude/agents/experts/testing/testing-build-agent.md
@@ -8,6 +8,9 @@ tools:
   - Glob
   - Grep
   - Bash
+  - mcp__kotadb-bunx__search_code
+  - mcp__kotadb-bunx__search_dependencies
+  - mcp__kotadb-bunx__analyze_change_impact
 model: sonnet
 color: green
 ---

--- a/.claude/agents/experts/testing/testing-improve-agent.md
+++ b/.claude/agents/experts/testing/testing-improve-agent.md
@@ -9,6 +9,8 @@ tools:
   - Grep
   - Bash
   - Task
+  - mcp__kotadb-bunx__search_code
+  - mcp__kotadb-bunx__search_dependencies
 model: sonnet
 color: purple
 ---

--- a/.claude/agents/experts/testing/testing-plan-agent.md
+++ b/.claude/agents/experts/testing/testing-plan-agent.md
@@ -7,6 +7,9 @@ tools:
   - Grep
   - Write
   - Bash
+  - mcp__kotadb-bunx__search_code
+  - mcp__kotadb-bunx__search_dependencies
+  - mcp__kotadb-bunx__list_recent_files
 model: sonnet
 color: yellow
 ---

--- a/.claude/agents/experts/testing/testing-question-agent.md
+++ b/.claude/agents/experts/testing/testing-question-agent.md
@@ -5,6 +5,9 @@ tools:
   - Read
   - Glob
   - Grep
+  - mcp__kotadb-bunx__search_code
+  - mcp__kotadb-bunx__search_dependencies
+  - mcp__kotadb-bunx__list_recent_files
 model: haiku
 color: cyan
 readOnly: true


### PR DESCRIPTION
## Summary

- Add KotaDB MCP tools (`search_code`, `search_dependencies`, `list_recent_files`, `analyze_change_impact`) to all 28 expert domain agents
- Fix MCP tool prefix from `mcp__kotadb__` to `mcp__kotadb-bunx__` (per `.mcp.json` server name)
- Add missing github domain agents to `agent-registry.json`
- Update `toolMatrix` in registry with all expert agent mappings
- Capture MCP naming patterns in agent-authoring expertise

## Tool Distribution

| Agent Type | MCP Tools |
|------------|-----------|
| Plan agents (7) | `search_code`, `search_dependencies`, `list_recent_files` |
| Build agents (7) | `search_code`, `search_dependencies`, `analyze_change_impact` |
| Improve agents (7) | `search_code`, `search_dependencies` |
| Question agents (7) | `search_code`, `search_dependencies`, `list_recent_files` |

## Files Changed

- 28 expert agent markdown files (7 domains × 4 agents)
- 1 agent-registry.json (agents + toolMatrix sections)
- 1 expertise.yaml (MCP naming patterns)

## Test Plan

- [ ] Verify expert agents can invoke MCP tools during workflows
- [ ] Confirm `search_code` returns results when used by plan-agent
- [ ] Confirm `analyze_change_impact` works for build-agent
- [ ] Verify agent-registry.json toolMatrix is consistent with frontmatter

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)