### PR TITLE
docs: clarify Bun runtime requirement and remove npx claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,17 @@ KotaDB is a local-only code intelligence tool for CLI Agents like Claude Code an
 
 ### Prerequisites
 
-- [Bun](https://bun.sh) v1.1+
+- [Bun](https://bun.sh) v1.1+ (required for both development and runtime)
 
-### Installation via npm
+> **Note:** KotaDB requires Bun to run. The package uses TypeScript path aliases that Bun resolves at runtime. Node.js/npx is not supported.
 
-KotaDB can be installed globally or run directly with npx/bunx:
+### Installation
+
+KotaDB can be installed globally or run directly with bunx:
 
 ```bash
 # Run directly (recommended)
 bunx kotadb --stdio
-
-# Or with npx
-npx kotadb --stdio
 
 # Or install globally
 bun add -g kotadb


### PR DESCRIPTION
## Summary

- Clarify that Bun is required for runtime (not just development)
- Remove misleading `npx kotadb` installation option
- Add note explaining why: TypeScript path aliases are resolved by Bun at runtime

## Context

Issue #33 reported that `npx kotadb` fails with:
```
error: Cannot find module '@api/routes'
```

This is because Node.js doesn't read `tsconfig.json` path mappings at runtime, while Bun does. Rather than adding a build step to resolve aliases, we're documenting that Bun is the supported runtime.

## Test plan

- [x] Verify README changes are accurate
- [x] Confirm `bunx kotadb --stdio` still works

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)