### PR TITLE
fix(package): include SQL files in npm package for bunx compatibility

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -10,6 +10,7 @@
   "files": [
     "src/**/*.ts",
     "src/**/*.js",
+    "src/**/*.sql",
     "!src/**/*.test.ts",
     "!src/**/*.spec.ts",
     "tsconfig.json",


### PR DESCRIPTION
## Summary

- Fix ENOENT error when running `bunx kotadb@next` - the sqlite-schema.sql file was not being included in the npm package
- Add `src/**/*.sql` pattern to the `files` array in package.json

## Problem

When running `bunx kotadb@next`, users encountered:
```
ENOENT: no such file or directory, open '/private/var/folders/.../bunx-501-kotadb@next/
node_modules/kotadb/src/db/sqlite-schema.sql'
```

The `files` array in package.json only included `.ts` and `.js` files, excluding the SQL schema files that are read at runtime.

## Solution

Added `"src/**/*.sql"` to the files array, which now includes:
- `src/db/sqlite-schema.sql` (main schema - the one that was failing)
- `src/db/schema.sql`
- `src/db/functions/increment_rate_limit.sql`
- `src/db/functions/increment_rate_limit_daily.sql`

## Test plan

- [ ] After merging, publish new version: `cd app && npm publish --tag next`
- [ ] Verify fix: `bunx kotadb@next --stdio` should start without ENOENT error
- [ ] Verify SQL files included: `npm pack --dry-run | grep sql`

🤖 Generated with [Claude Code](https://claude.com/claude-code)