### PR TITLE
fix(agents): correct MCP tool naming and add usage guidance

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -76,8 +76,8 @@ Select agents by model tier:
 - `Glob` - File pattern matching
 - `Grep` - Content search
 - `Read` - File reading
-- `mcp__kotadb__search_code` - Code search via MCP
-- `mcp__kotadb__search_dependencies` - Dependency analysis via MCP
+- `mcp__kotadb-bunx__search_code` - Code search via MCP
+- `mcp__kotadb-bunx__search_dependencies` - Dependency analysis via MCP
 
 ### Write Tools
 - `Edit` - File modification
@@ -87,7 +87,7 @@ Select agents by model tier:
 
 ### Analysis Tools
 - `WebFetch` - URL content fetching
-- `mcp__kotadb__analyze_change_impact` - Change impact analysis
+- `mcp__kotadb-bunx__analyze_change_impact` - Change impact analysis
 - `mcp__firecrawl-mcp__firecrawl_scrape` - Web scraping
 
 ## Agent Selection Guidelines

--- a/.claude/agents/build-agent.md
+++ b/.claude/agents/build-agent.md
@@ -11,9 +11,9 @@ tools:
   - NotebookEdit
   - Task
   - TodoWrite
-  - mcp__kotadb__search_code
-  - mcp__kotadb__search_dependencies
-  - mcp__kotadb__analyze_change_impact
+  - mcp__kotadb-bunx__search_code
+  - mcp__kotadb-bunx__search_dependencies
+  - mcp__kotadb-bunx__analyze_change_impact
 constraints:
   - Follow existing code patterns
   - Validate changes with lint and typecheck
@@ -52,9 +52,9 @@ The build-agent handles all implementation tasks that require modifying the code
 - **TodoWrite**: Track implementation progress
 
 ### Analysis
-- **mcp__kotadb__search_code**: Find relevant code patterns
-- **mcp__kotadb__search_dependencies**: Understand impact areas
-- **mcp__kotadb__analyze_change_impact**: Assess risk of changes
+- **mcp__kotadb-bunx__search_code**: Find relevant code patterns
+- **mcp__kotadb-bunx__search_dependencies**: Understand impact areas
+- **mcp__kotadb-bunx__analyze_change_impact**: Assess risk of changes
 
 ## Constraints
 
@@ -63,6 +63,14 @@ The build-agent handles all implementation tasks that require modifying the code
 3. **Incremental commits**: Create logical commit units, not monolithic changes
 4. **Security awareness**: Avoid introducing OWASP top 10 vulnerabilities
 5. **Minimal changes**: Only modify what is necessary for the task
+
+## KotaDB MCP Tool Usage
+
+When working with this codebase:
+- **Before refactoring**: Use `mcp__kotadb-bunx__search_dependencies` to understand file relationships
+- **Before PRs/changes**: Use `mcp__kotadb-bunx__analyze_change_impact` to assess risk
+- **For code discovery**: Prefer `mcp__kotadb-bunx__search_code` for semantic searches
+- **Fallback to Grep**: Only for exact regex patterns or unindexed files
 
 ## Workflow
 

--- a/.claude/agents/experts/agent-authoring/agent-authoring-improve-agent.md
+++ b/.claude/agents/experts/agent-authoring/agent-authoring-improve-agent.md
@@ -96,7 +96,7 @@ When approaching limits:
 
 4. **Identify Effective Patterns**
    - New agent organization approaches
-   - MCP tool usage patterns (mcp__kotadb__)
+   - MCP tool usage patterns (mcp__kotadb-bunx__)
    - Improved prompt structure techniques
    - Registry update workflows
    - Expert domain patterns

--- a/.claude/agents/experts/agent-authoring/agent-authoring-plan-agent.md
+++ b/.claude/agents/experts/agent-authoring/agent-authoring-plan-agent.md
@@ -169,7 +169,7 @@ expertDomain: <domain if applicable>
 **Tool Selection Rationale:**
 - Role category: <scout|build|review|expert-*>
 - Selected tools: <list with reasoning>
-- MCP tools: <mcp__kotadb__* as needed>
+- MCP tools: <mcp__kotadb-bunx__* as needed>
 
 **Model Selection Rationale:**
 - Complexity level: <simple|moderate|complex>

--- a/.claude/agents/experts/agent-authoring/agent-authoring-question-agent.md
+++ b/.claude/agents/experts/agent-authoring/agent-authoring-question-agent.md
@@ -47,7 +47,7 @@ You are an Agent Authoring Expert specializing in answering questions about kota
 
 *[2026-01-26]*: Frontmatter format questions - kotadb uses YAML list for tools (not comma-separated). NEVER use colons in description. Include constraints[], readOnly, expertDomain as applicable.
 
-*[2026-01-26]*: MCP tool questions - mcp__kotadb__* for codebase search and analysis. See `patterns.mcp_tool_patterns` in expertise.yaml.
+*[2026-01-26]*: MCP tool questions - mcp__kotadb-bunx__* for codebase search and analysis. See `patterns.mcp_tool_patterns` in expertise.yaml.
 
 *[2026-01-26]*: Registry integration - agent-registry.json has agents, capabilityIndex, modelIndex, toolMatrix. All new agents must be registered. See `key_operations.update_agent_registry`.
 

--- a/.claude/agents/experts/agent-authoring/expertise.yaml.backup
+++ b/.claude/agents/experts/agent-authoring/expertise.yaml.backup
@@ -5,7 +5,7 @@ overview:
   description: |
     Agent authoring and configuration for kotadb—frontmatter schema with tools[], constraints[],
     readOnly, expertDomain, and color fields; flat agent structure with general-purpose and expert agents;
-    agent-registry.json integration; MCP tool selection (mcp__kotadb__*); and system prompt
+    agent-registry.json integration; MCP tool selection (mcp__kotadb-bunx__*); and system prompt
     structure. This expertise enables correct agent configuration for discoverability, capability,
     and appropriate model selection within kotadb's local-only architecture.
   scope: |
@@ -117,15 +117,15 @@ key_operations:
       - Question: Read, Glob, Grep (read-only, haiku model)
 
       KotaDB MCP tools (for codebase analysis):
-      - mcp__kotadb__search_code (term)
-      - mcp__kotadb__search_dependencies (file_path, direction, depth)
-      - mcp__kotadb__analyze_change_impact (files)
-      - mcp__kotadb__list_recent_files ()
+      - mcp__kotadb-bunx__search_code (term)
+      - mcp__kotadb-bunx__search_dependencies (file_path, direction, depth)
+      - mcp__kotadb-bunx__analyze_change_impact (files)
+      - mcp__kotadb-bunx__list_recent_files ()
     examples:
       - role: scout-agent
         tools: Read, Glob, Grep
       - role: build-agent
-        tools: Read, Write, Edit, Bash, Glob, Grep, mcp__kotadb__search_code
+        tools: Read, Write, Edit, Bash, Glob, Grep, mcp__kotadb-bunx__search_code
       - role: expert-plan
         tools: Read, Glob, Grep, Write
 
@@ -419,10 +419,10 @@ patterns:
     context: kotadb uses MCP tools for codebase search and analysis
     implementation: |
       KotaDB MCP tools (search and analysis):
-      - mcp__kotadb__search_code(term)
-      - mcp__kotadb__search_dependencies(file_path, direction, depth)
-      - mcp__kotadb__analyze_change_impact(files)
-      - mcp__kotadb__list_recent_files()
+      - mcp__kotadb-bunx__search_code(term)
+      - mcp__kotadb-bunx__search_dependencies(file_path, direction, depth)
+      - mcp__kotadb-bunx__analyze_change_impact(files)
+      - mcp__kotadb-bunx__list_recent_files()
 
       Tool selection by agent type:
       - scout-agent: Optional kotadb search tools
@@ -574,4 +574,4 @@ stability:
       - Registry v2.0.0 with comprehensive indexes
       - Removed branch/leaf references completely
       - Removed Supabase references (now SQLite only)
-      - MCP tools limited to mcp__kotadb__* for local search
+      - MCP tools limited to mcp__kotadb-bunx__* for local search

--- a/.claude/agents/experts/claude-config/claude-config-build-agent.md
+++ b/.claude/agents/experts/claude-config/claude-config-build-agent.md
@@ -116,7 +116,7 @@ What the command returns.
 - Tools as YAML array (NOT comma-separated)
 - Valid models: `haiku`, `sonnet`, `opus`
 - Valid colors: red, blue, green, yellow, purple, orange, pink, cyan
-- MCP tools: `mcp__kotadb__search_code`, etc.
+- MCP tools: `mcp__kotadb-bunx__search_code`, etc.
 - CRITICAL: Description MUST NOT contain colons
 
 **Agent Frontmatter:**
@@ -128,7 +128,7 @@ tools:
   - Read
   - Glob
   - Grep
-  - mcp__kotadb__search_code
+  - mcp__kotadb-bunx__search_code
 model: sonnet
 color: blue
 constraints:

--- a/.claude/agents/experts/claude-config/claude-config-plan-agent.md
+++ b/.claude/agents/experts/claude-config/claude-config-plan-agent.md
@@ -99,7 +99,7 @@ Use Bash for git operations, file statistics, or verification commands.
 - Tools as YAML array (NOT comma-separated)
 - Valid models: `haiku`, `sonnet`, `opus`
 - Valid colors: red, blue, green, yellow, purple, orange, pink, cyan
-- MCP tools: `mcp__kotadb__search_code`, `mcp__kotadb__search_dependencies`, `mcp__kotadb__analyze_change_impact`
+- MCP tools: `mcp__kotadb-bunx__search_code`, `mcp__kotadb-bunx__search_dependencies`, `mcp__kotadb-bunx__analyze_change_impact`
 - CRITICAL: Description must NOT contain colons
 
 **Agent Registry:**

--- a/.claude/agents/experts/claude-config/claude-config-question-agent.md
+++ b/.claude/agents/experts/claude-config/claude-config-question-agent.md
@@ -104,7 +104,7 @@ constraints:
 
 **"How do I list tools in agent frontmatter?"**
 - Use YAML array format (NOT comma-separated)
-- MCP tools: `mcp__kotadb__search_code`, etc.
+- MCP tools: `mcp__kotadb-bunx__search_code`, etc.
 - Valid tools: Read, Write, Edit, Bash, Glob, Grep, Task, etc.
 
 **"Why isn't my agent appearing in discovery?"**

--- a/.claude/agents/experts/claude-config/expertise.yaml
+++ b/.claude/agents/experts/claude-config/expertise.yaml
@@ -185,7 +185,7 @@ key_operations:
       9. Update /do command with domain detection patterns
     kotadb_adaptations:
       - Use YAML array format for tools (NOT comma-separated)
-      - Add MCP tools where appropriate (mcp__kotadb__*)
+      - Add MCP tools where appropriate (mcp__kotadb-bunx__*)
       - Update agent-registry.json capabilityIndex, modelIndex, toolMatrix
     pitfalls:
       - what: "CRITICAL - Using colons in agent description field"
@@ -399,7 +399,7 @@ patterns:
         - Read
         - Glob
         - Grep
-        - mcp__kotadb__search_code
+        - mcp__kotadb-bunx__search_code
       model: haiku|sonnet|opus
       color: yellow|green|purple|cyan
       constraints:
@@ -493,7 +493,7 @@ best_practices:
     - Include model and color fields for expert agents
     - Update agent-registry.json for every new agent
     - CRITICAL: Never use colons in description field
-    - Add MCP tools where appropriate (mcp__kotadb__*)
+    - Add MCP tools where appropriate (mcp__kotadb-bunx__*)
     - Apply "permissive tools + strict prompts" philosophy
 
   hooks:

--- a/.claude/agents/review-agent.md
+++ b/.claude/agents/review-agent.md
@@ -6,9 +6,9 @@ tools:
   - Grep
   - Read
   - Task
-  - mcp__kotadb__search_code
-  - mcp__kotadb__search_dependencies
-  - mcp__kotadb__analyze_change_impact
+  - mcp__kotadb-bunx__search_code
+  - mcp__kotadb-bunx__search_dependencies
+  - mcp__kotadb-bunx__analyze_change_impact
   - WebFetch
 constraints:
   - No file modifications
@@ -38,9 +38,9 @@ The review-agent analyzes code changes and provides constructive feedback:
 - **Read**: Read files for detailed analysis
 
 ### Code Intelligence
-- **mcp__kotadb__search_code**: Find similar patterns in codebase
-- **mcp__kotadb__search_dependencies**: Understand impact of changes
-- **mcp__kotadb__analyze_change_impact**: Assess risk and scope
+- **mcp__kotadb-bunx__search_code**: Find similar patterns in codebase
+- **mcp__kotadb-bunx__search_dependencies**: Understand impact of changes
+- **mcp__kotadb-bunx__analyze_change_impact**: Assess risk and scope
 
 ### Context Gathering
 - **WebFetch**: Fetch documentation or issue context
@@ -52,6 +52,14 @@ The review-agent analyzes code changes and provides constructive feedback:
 2. **Actionable feedback**: Comments must be specific and actionable
 3. **Line references**: Always include file paths and line numbers
 4. **Balanced review**: Note both issues and positive aspects
+
+## KotaDB MCP Tool Usage
+
+When working with this codebase:
+- **Before refactoring**: Use `mcp__kotadb-bunx__search_dependencies` to understand file relationships
+- **Before PRs/changes**: Use `mcp__kotadb-bunx__analyze_change_impact` to assess risk
+- **For code discovery**: Prefer `mcp__kotadb-bunx__search_code` for semantic searches
+- **Fallback to Grep**: Only for exact regex patterns or unindexed files
 
 ## Review Checklist
 

--- a/.claude/agents/scout-agent.md
+++ b/.claude/agents/scout-agent.md
@@ -7,9 +7,9 @@ tools:
   - Read
   - Task
   - Bash
-  - mcp__kotadb__search_code
-  - mcp__kotadb__search_dependencies
-  - mcp__kotadb__list_recent_files
+  - mcp__kotadb-bunx__search_code
+  - mcp__kotadb-bunx__search_dependencies
+  - mcp__kotadb-bunx__list_recent_files
 constraints:
   - No file modifications allowed
   - No shell command execution
@@ -38,11 +38,11 @@ The scout-agent is designed for tasks that require understanding code without mo
 
 ### Content Search
 - **Grep**: Search file contents with regex patterns
-- **mcp__kotadb__search_code**: Semantic code search across indexed repositories
+- **mcp__kotadb-bunx__search_code**: Semantic code search across indexed repositories
 
 ### Dependency Analysis
-- **mcp__kotadb__search_dependencies**: Find files that depend on or are depended on by a target file
-- **mcp__kotadb__list_recent_files**: View recently indexed files
+- **mcp__kotadb-bunx__search_dependencies**: Find files that depend on or are depended on by a target file
+- **mcp__kotadb-bunx__list_recent_files**: View recently indexed files
 
 ### Delegation
 - **Task**: Spawn sub-agents for complex multi-step exploration
@@ -52,6 +52,14 @@ The scout-agent is designed for tasks that require understanding code without mo
 1. **Read-only access**: Cannot use Edit, Write, or Bash tools
 2. **No side effects**: Must not modify any files or execute commands
 3. **Information gathering only**: Reports findings for human or build-agent action
+
+## KotaDB MCP Tool Usage
+
+When working with this codebase:
+- **Before refactoring**: Use `mcp__kotadb-bunx__search_dependencies` to understand file relationships
+- **Before PRs/changes**: Use `mcp__kotadb-bunx__analyze_change_impact` to assess risk
+- **For code discovery**: Prefer `mcp__kotadb-bunx__search_code` for semantic searches
+- **Fallback to Grep**: Only for exact regex patterns or unindexed files
 
 ## Use Cases
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,4 +88,22 @@ cd app && bun run lint
 
 ## MCP Server
 
-KotaDB provides MCP tools for code search, indexing, and dependency analysis. 
+KotaDB provides MCP tools for code search, indexing, and dependency analysis.
+
+### Tool Selection Guide
+
+**PREFER KotaDB MCP tools for:**
+- `mcp__kotadb-bunx__search_dependencies` - Understanding file relationships before refactoring
+- `mcp__kotadb-bunx__analyze_change_impact` - Risk assessment before PRs or major changes
+- `mcp__kotadb-bunx__search_code` - Semantic/conceptual code discovery across indexed repos
+
+**FALLBACK to Grep for:**
+- Exact regex pattern matching
+- Unindexed files or live filesystem searches
+- Quick single-file searches
+
+**Decision Tree:**
+1. Refactoring or modifying files? → Use `search_dependencies` first
+2. Creating PR or significant change? → Use `analyze_change_impact`
+3. Finding code by concept/meaning? → Try `search_code`
+4. Need exact regex or live results? → Use Grep


### PR DESCRIPTION
## Summary

- **Fix naming mismatch**: Replace `mcp__kotadb__` with `mcp__kotadb-bunx__` across all 13 agent files
- **Add tool selection guidance**: New section in CLAUDE.md with decision tree for when to use MCP tools vs Grep
- **Add MCP preference to core agents**: Build, scout, and review agents now have explicit guidance on using KotaDB tools

## Changes

| Category | Files | Changes |
|----------|-------|---------|
| Core agents | 3 | Fixed naming (18 replacements) + added MCP usage section |
| Expert agents | 6 | Fixed naming in claude-config and agent-authoring domains |
| Config files | 3 | README.md, expertise.yaml, expertise.yaml.backup |
| Documentation | 1 | CLAUDE.md - added Tool Selection Guide |

## Verification

- ✅ 0 instances of wrong naming `mcp__kotadb__` remain
- ✅ 256 instances of correct naming `mcp__kotadb-bunx__` across all files
- ✅ Tool Selection Guide added to CLAUDE.md with decision tree

## Test plan

- [ ] Verify agents use correct tool names when spawned
- [ ] Confirm MCP tools are accessible with new naming
- [ ] Test that guidance appears in agent prompts

Fixes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)