### PR TITLE
feat(mcp): support repository full_name in addition to UUID (#96)

### DIFF
--- a/app/src/mcp/repository-resolver.ts
+++ b/app/src/mcp/repository-resolver.ts
@@ -1,0 +1,91 @@
+/**
+ * Repository identifier resolution utilities
+ *
+ * Supports both UUID and full_name formats for user convenience
+ */
+
+import { getGlobalDatabase } from "@db/sqlite/index.js";
+
+/** UUID v4 pattern */
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Check if a string is a valid UUID
+ */
+export function isUUID(value: string): boolean {
+	return UUID_PATTERN.test(value);
+}
+
+/**
+ * Resolve a repository identifier (UUID or full_name) to a repository ID
+ *
+ * @param identifier - Repository UUID or full_name (e.g., "local/kotadb")
+ * @returns Repository ID or null if not found
+ */
+export function resolveRepositoryParam(identifier: string | undefined): string | null {
+	const db = getGlobalDatabase();
+
+	if (!identifier) {
+		// Fall back to most recently created repository
+		const repo = db.queryOne<{ id: string }>(
+			"SELECT id FROM repositories ORDER BY created_at DESC LIMIT 1",
+			[],
+		);
+		return repo?.id ?? null;
+	}
+
+	// Check if it's a UUID - return as-is without validation
+	if (isUUID(identifier)) {
+		return identifier;
+	}
+
+	// Treat as full_name
+	const repo = db.queryOne<{ id: string }>(
+		"SELECT id FROM repositories WHERE full_name = ?",
+		[identifier],
+	);
+	return repo?.id ?? null;
+}
+
+/**
+ * Alias for resolveRepositoryParam for backward compatibility
+ */
+export const resolveRepositoryIdentifier = resolveRepositoryParam;
+
+/**
+ * Resolve a repository identifier with detailed error information
+ *
+ * @param identifier - Repository UUID or full_name
+ * @returns Object with id (if found) or error message
+ */
+export function resolveRepositoryIdentifierWithError(
+	identifier: string | undefined,
+): { id: string } | { error: string } {
+	const db = getGlobalDatabase();
+
+	if (!identifier) {
+		const repo = db.queryOne<{ id: string }>(
+			"SELECT id FROM repositories ORDER BY created_at DESC LIMIT 1",
+			[],
+		);
+		if (!repo) {
+			return { error: "No repositories found. Please index a repository first using index_repository tool." };
+		}
+		return { id: repo.id };
+	}
+
+	// Check if it's a UUID - return as-is without validation
+	if (isUUID(identifier)) {
+		return { id: identifier };
+	}
+
+	// Treat as full_name
+	const repo = db.queryOne<{ id: string }>(
+		"SELECT id FROM repositories WHERE full_name = ?",
+		[identifier],
+	);
+	if (!repo) {
+		return { error: `Repository not found: ${identifier}. Use a valid repository UUID or full_name.` };
+	}
+	return { id: repo.id };
+}

--- a/app/src/mcp/spec-validation.ts
+++ b/app/src/mcp/spec-validation.ts
@@ -12,10 +12,10 @@
  */
 
 import { resolveFilePath } from "@api/queries";
-import { getGlobalDatabase } from "@db/sqlite/index.js";
 import { createLogger } from "@logging/logger.js";
 import type { ImplementationSpec, ValidationIssue, ValidationResult } from "@shared/types";
 import { Sentry } from "../instrument.js";
+import { resolveRepositoryIdentifier } from "./repository-resolver";
 
 const logger = createLogger({ module: "mcp-spec-validation" });
 
@@ -36,8 +36,8 @@ export async function validateImplementationSpec(
 	try {
 		logger.info("Starting spec validation", { feature_name: spec.feature_name, user_id: userId });
 
-		// Resolve repository ID from SQLite
-		const repositoryId = resolveRepositoryId(spec.repository);
+		// Resolve repository ID from SQLite (supports UUID or full_name)
+		const repositoryId = resolveRepositoryIdentifier(spec.repository);
 
 		if (!repositoryId) {
 			errors.push({
@@ -122,24 +122,6 @@ export async function validateImplementationSpec(
 		});
 		throw error;
 	}
-}
-
-/**
- * Resolve repository ID from request or use first available repository
- */
-function resolveRepositoryId(repositoryId: string | undefined): string | null {
-	if (repositoryId) {
-		return repositoryId;
-	}
-
-	// Get first repository from SQLite
-	const db = getGlobalDatabase();
-	const repo = db.queryOne<{ id: string }>(
-		"SELECT id FROM repositories ORDER BY created_at DESC LIMIT 1",
-		[],
-	);
-
-	return repo?.id ?? null;
 }
 
 /**

--- a/app/tests/mcp/repository-resolver.integration.test.ts
+++ b/app/tests/mcp/repository-resolver.integration.test.ts
@@ -1,0 +1,342 @@
+/**
+ * Integration tests for repository resolution in MCP tools
+ *
+ * Tests that MCP tools (search_dependencies, analyze_change_impact,
+ * validate_implementation_spec) correctly accept full_name format
+ * for the repository parameter.
+ *
+ * Following antimocking philosophy: uses real file-based SQLite databases
+ * with proper KOTADB_PATH environment isolation.
+ *
+ * @module tests/mcp/repository-resolver.integration
+ */
+
+import { describe, expect, test, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import {
+	executeSearchDependencies,
+	executeAnalyzeChangeImpact,
+	executeValidateImplementationSpec,
+} from "@mcp/tools.js";
+import { closeGlobalConnections, getGlobalDatabase } from "@db/sqlite/index.js";
+import type { KotaDatabase } from "@db/sqlite/index.js";
+import { createTempDir, cleanupTempDir, clearTestData } from "../helpers/db.js";
+
+describe("MCP tools repository resolution integration", () => {
+	let db: KotaDatabase;
+	let tempDir: string;
+	let dbPath: string;
+	let originalDbPath: string | undefined;
+	const testRepoId = "12345678-1234-1234-1234-123456789abc";
+	const testFullName = "integration-owner/integration-repo";
+	const requestId = "test-request";
+	const userId = "test-user";
+
+	beforeAll(() => {
+		tempDir = createTempDir("mcp-repo-integration-test-");
+		dbPath = join(tempDir, "test.db");
+
+		originalDbPath = process.env.KOTADB_PATH;
+		process.env.KOTADB_PATH = dbPath;
+		closeGlobalConnections();
+	});
+
+	afterAll(() => {
+		if (originalDbPath !== undefined) {
+			process.env.KOTADB_PATH = originalDbPath;
+		} else {
+			delete process.env.KOTADB_PATH;
+		}
+		closeGlobalConnections();
+		cleanupTempDir(tempDir);
+	});
+
+	beforeEach(() => {
+		db = getGlobalDatabase();
+
+		// Create test repository with known ID and full_name
+		db.run(
+			"INSERT INTO repositories (id, name, full_name, default_branch) VALUES (?, ?, ?, ?)",
+			[testRepoId, "integration-repo", testFullName, "main"],
+		);
+
+		// Create a test file for dependency searches
+		db.run(
+			`INSERT INTO indexed_files (id, repository_id, path, content, language, indexed_at, content_hash)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			[
+				randomUUID(),
+				testRepoId,
+				"src/index.ts",
+				"export const main = () => {};",
+				"typescript",
+				new Date().toISOString(),
+				randomUUID(),
+			],
+		);
+	});
+
+	afterEach(() => {
+		clearTestData(db);
+	});
+
+	describe("search_dependencies with full_name", () => {
+		test("should accept full_name as repository parameter", async () => {
+			const result = await executeSearchDependencies(
+				{
+					file_path: "src/index.ts",
+					repository: testFullName,
+				},
+				requestId,
+				userId,
+			) as { file_path: string; dependents: unknown; dependencies: unknown };
+
+			expect(result.file_path).toBe("src/index.ts");
+			expect(result.dependents).toBeDefined();
+			expect(result.dependencies).toBeDefined();
+		});
+
+		test("should accept UUID as repository parameter (backward compatibility)", async () => {
+			const result = await executeSearchDependencies(
+				{
+					file_path: "src/index.ts",
+					repository: testRepoId,
+				},
+				requestId,
+				userId,
+			) as { file_path: string };
+
+			expect(result.file_path).toBe("src/index.ts");
+		});
+
+		test("should return error message for invalid full_name", async () => {
+			const result = await executeSearchDependencies(
+				{
+					file_path: "src/index.ts",
+					repository: "nonexistent/repo",
+				},
+				requestId,
+				userId,
+			) as { message: string };
+
+			expect(result.message).toContain("Repository not found");
+			expect(result.message).toContain("nonexistent/repo");
+		});
+
+		test("should fall back to first repository when no repository specified", async () => {
+			const result = await executeSearchDependencies(
+				{
+					file_path: "src/index.ts",
+				},
+				requestId,
+				userId,
+			) as { file_path: string };
+
+			// Should not error - uses first available repository
+			expect(result.file_path).toBe("src/index.ts");
+		});
+	});
+
+	describe("analyze_change_impact with full_name", () => {
+		test("should accept full_name as repository parameter", async () => {
+			const result = await executeAnalyzeChangeImpact(
+				{
+					change_type: "feature",
+					description: "Add new feature",
+					repository: testFullName,
+				},
+				requestId,
+				userId,
+			) as { affected_files: unknown; risk_level: string };
+
+			expect(result.affected_files).toBeDefined();
+			expect(result.risk_level).toBeDefined();
+		});
+
+		test("should accept UUID as repository parameter (backward compatibility)", async () => {
+			const result = await executeAnalyzeChangeImpact(
+				{
+					change_type: "refactor",
+					description: "Refactor code",
+					repository: testRepoId,
+				},
+				requestId,
+				userId,
+			) as { risk_level: string };
+
+			expect(result.risk_level).toBeDefined();
+		});
+
+		test("should handle invalid full_name gracefully", async () => {
+			const result = await executeAnalyzeChangeImpact(
+				{
+					change_type: "fix",
+					description: "Bug fix",
+					repository: "invalid/nonexistent",
+				},
+				requestId,
+				userId,
+			) as { error?: string; risk_level?: string };
+
+			// Should either return error or handle gracefully
+			expect(result.error || result.risk_level).toBeDefined();
+		});
+
+		test("should fall back to first repository when no repository specified", async () => {
+			const result = await executeAnalyzeChangeImpact(
+				{
+					change_type: "chore",
+					description: "Maintenance task",
+				},
+				requestId,
+				userId,
+			) as { risk_level: string };
+
+			expect(result.risk_level).toBeDefined();
+		});
+	});
+
+	describe("validate_implementation_spec with full_name", () => {
+		test("should accept full_name as repository parameter", async () => {
+			const result = await executeValidateImplementationSpec(
+				{
+					feature_name: "New Feature",
+					repository: testFullName,
+				},
+				requestId,
+				userId,
+			) as { valid: boolean; errors: unknown[]; warnings: unknown[] };
+
+			expect(result.valid).toBeDefined();
+			expect(result.errors).toBeDefined();
+			expect(result.warnings).toBeDefined();
+		});
+
+		test("should accept UUID as repository parameter (backward compatibility)", async () => {
+			const result = await executeValidateImplementationSpec(
+				{
+					feature_name: "Another Feature",
+					repository: testRepoId,
+				},
+				requestId,
+				userId,
+			) as { valid: boolean };
+
+			expect(result.valid).toBeDefined();
+		});
+
+		test("should handle invalid full_name gracefully", async () => {
+			const result = await executeValidateImplementationSpec(
+				{
+					feature_name: "Test Feature",
+					repository: "does-not/exist",
+				},
+				requestId,
+				userId,
+			) as { error?: string; valid?: boolean };
+
+			// Should either return error or handle gracefully
+			expect(result.error || result.valid !== undefined).toBe(true);
+		});
+
+		test("should fall back to first repository when no repository specified", async () => {
+			const result = await executeValidateImplementationSpec(
+				{
+					feature_name: "Fallback Feature",
+				},
+				requestId,
+				userId,
+			) as { valid: boolean };
+
+			expect(result.valid).toBeDefined();
+		});
+	});
+
+	describe("edge cases", () => {
+		test("should handle full_name with special characters in owner", async () => {
+			const specialRepoId = randomUUID();
+			db.run(
+				"INSERT INTO repositories (id, name, full_name, default_branch) VALUES (?, ?, ?, ?)",
+				[specialRepoId, "repo", "owner-with-dash/repo", "main"],
+			);
+
+			const result = await executeSearchDependencies(
+				{
+					file_path: "src/test.ts",
+					repository: "owner-with-dash/repo",
+				},
+				requestId,
+				userId,
+			) as { file_path: string };
+
+			expect(result.file_path).toBe("src/test.ts");
+		});
+
+		test("should handle local/ prefix for local repositories", async () => {
+			const localRepoId = randomUUID();
+			db.run(
+				"INSERT INTO repositories (id, name, full_name, default_branch) VALUES (?, ?, ?, ?)",
+				[localRepoId, "myproject", "local/myproject", "main"],
+			);
+
+			db.run(
+				`INSERT INTO indexed_files (id, repository_id, path, content, language, indexed_at, content_hash)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+				[randomUUID(), localRepoId, "src/main.ts", "export {};", "typescript", new Date().toISOString(), randomUUID()],
+			);
+
+			const result = await executeSearchDependencies(
+				{
+					file_path: "src/main.ts",
+					repository: "local/myproject",
+				},
+				requestId,
+				userId,
+			) as { file_path: string };
+
+			expect(result.file_path).toBe("src/main.ts");
+		});
+
+		test("should distinguish between similar full_names", async () => {
+			const repo1Id = randomUUID();
+			const repo2Id = randomUUID();
+
+			db.run(
+				"INSERT INTO repositories (id, name, full_name, default_branch) VALUES (?, ?, ?, ?)",
+				[repo1Id, "repo", "owner1/repo", "main"],
+			);
+			db.run(
+				"INSERT INTO repositories (id, name, full_name, default_branch) VALUES (?, ?, ?, ?)",
+				[repo2Id, "repo", "owner2/repo", "main"],
+			);
+
+			db.run(
+				`INSERT INTO indexed_files (id, repository_id, path, content, language, indexed_at, content_hash)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+				[randomUUID(), repo1Id, "src/file.ts", "// owner1", "typescript", new Date().toISOString(), randomUUID()],
+			);
+			db.run(
+				`INSERT INTO indexed_files (id, repository_id, path, content, language, indexed_at, content_hash)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+				[randomUUID(), repo2Id, "src/file.ts", "// owner2", "typescript", new Date().toISOString(), randomUUID()],
+			);
+
+			// Both should resolve correctly to their respective repositories
+			const result1 = await executeSearchDependencies(
+				{ file_path: "src/file.ts", repository: "owner1/repo" },
+				requestId,
+				userId,
+			) as { file_path: string };
+
+			const result2 = await executeSearchDependencies(
+				{ file_path: "src/file.ts", repository: "owner2/repo" },
+				requestId,
+				userId,
+			) as { file_path: string };
+
+			expect(result1.file_path).toBe("src/file.ts");
+			expect(result2.file_path).toBe("src/file.ts");
+		});
+	});
+});

--- a/app/tests/mcp/repository-resolver.test.ts
+++ b/app/tests/mcp/repository-resolver.test.ts
@@ -1,0 +1,323 @@
+/**
+ * Unit tests for repository-resolver module
+ *
+ * Following antimocking philosophy: uses real file-based SQLite databases
+ * with proper KOTADB_PATH environment isolation.
+ *
+ * Test Coverage:
+ * - isUUID: UUID format validation
+ * - resolveRepositoryIdentifier: UUID/full_name resolution
+ * - resolveRepositoryIdentifierWithError: Error handling variant
+ *
+ * @module tests/mcp/repository-resolver
+ */
+
+import { describe, expect, test, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import {
+	isUUID,
+	resolveRepositoryIdentifier,
+	resolveRepositoryIdentifierWithError,
+	resolveRepositoryParam,
+} from "@mcp/repository-resolver.js";
+import { closeGlobalConnections, getGlobalDatabase } from "@db/sqlite/index.js";
+import type { KotaDatabase } from "@db/sqlite/index.js";
+import { createTempDir, cleanupTempDir, clearTestData } from "../helpers/db.js";
+
+describe("isUUID", () => {
+	test("should return true for valid lowercase UUID", () => {
+		expect(isUUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")).toBe(true);
+	});
+
+	test("should return true for valid uppercase UUID", () => {
+		expect(isUUID("A1B2C3D4-E5F6-7890-ABCD-EF1234567890")).toBe(true);
+	});
+
+	test("should return true for valid mixed case UUID", () => {
+		expect(isUUID("A1b2C3d4-E5f6-7890-AbCd-Ef1234567890")).toBe(true);
+	});
+
+	test("should return true for randomUUID output", () => {
+		const uuid = randomUUID();
+		expect(isUUID(uuid)).toBe(true);
+	});
+
+	test("should return false for full_name format (owner/repo)", () => {
+		expect(isUUID("owner/repo")).toBe(false);
+	});
+
+	test("should return false for local full_name format", () => {
+		expect(isUUID("local/kotadb")).toBe(false);
+	});
+
+	test("should return false for empty string", () => {
+		expect(isUUID("")).toBe(false);
+	});
+
+	test("should return false for random string", () => {
+		expect(isUUID("not-a-uuid")).toBe(false);
+	});
+
+	test("should return false for UUID without dashes", () => {
+		expect(isUUID("a1b2c3d4e5f67890abcdef1234567890")).toBe(false);
+	});
+
+	test("should return false for partial UUID", () => {
+		expect(isUUID("a1b2c3d4-e5f6-7890")).toBe(false);
+	});
+
+	test("should return false for UUID with extra characters", () => {
+		expect(isUUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890-extra")).toBe(false);
+	});
+});
+
+describe("resolveRepositoryIdentifier", () => {
+	let db: KotaDatabase;
+	let tempDir: string;
+	let dbPath: string;
+	let originalDbPath: string | undefined;
+	const testRepoId = "11111111-2222-3333-4444-555555555555";
+	const testFullName = "test-owner/test-repo";
+
+	beforeAll(() => {
+		// Create temp directory and set KOTADB_PATH for test isolation
+		tempDir = createTempDir("mcp-repo-resolver-test-");
+		dbPath = join(tempDir, "test.db");
+
+		originalDbPath = process.env.KOTADB_PATH;
+		process.env.KOTADB_PATH = dbPath;
+		closeGlobalConnections();
+	});
+
+	afterAll(() => {
+		// Restore original KOTADB_PATH
+		if (originalDbPath !== undefined) {
+			process.env.KOTADB_PATH = originalDbPath;
+		} else {
+			delete process.env.KOTADB_PATH;
+		}
+		closeGlobalConnections();
+		cleanupTempDir(tempDir);
+	});
+
+	beforeEach(() => {
+		db = getGlobalDatabase();
+	});
+
+	afterEach(() => {
+		clearTestData(db);
+	});
+
+	test("should return null when no repositories exist and param is undefined", () => {
+		const result = resolveRepositoryIdentifier(undefined);
+		expect(result).toBeNull();
+	});
+
+	test("should return first repository ID when param is undefined", () => {
+		// Create a test repository
+		db.run(
+			"INSERT INTO repositories (id, name, full_name, default_branch) VALUES (?, ?, ?, ?)",
+			[testRepoId, "test-repo", testFullName, "main"],
+		);
+
+		const result = resolveRepositoryIdentifier(undefined);
+		expect(result).toBe(testRepoId);
+	});
+
+	test("should return most recent repository when multiple exist and param is undefined", () => {
+		const olderRepoId = randomUUID();
+		const newerRepoId = randomUUID();
+
+		// Insert older repository first
+		db.run(
+			"INSERT INTO repositories (id, name, full_name, default_branch, created_at) VALUES (?, ?, ?, ?, ?)",
+			[olderRepoId, "older-repo", "owner/older-repo", "main", "2024-01-01T00:00:00Z"],
+		);
+
+		// Insert newer repository
+		db.run(
+			"INSERT INTO repositories (id, name, full_name, default_branch, created_at) VALUES (?, ?, ?, ?, ?)",
+			[newerRepoId, "newer-repo", "owner/newer-repo", "main", "2025-01-01T00:00:00Z"],
+		);
+
+		const result = resolveRepositoryIdentifier(undefined);
+		expect(result).toBe(newerRepoId);
+	});
+
+	test("should return UUID as-is when valid UUID provided (passthrough)", () => {
+		const inputUuid = randomUUID();
+		const result = resolveRepositoryIdentifier(inputUuid);
+		expect(result).toBe(inputUuid);
+	});
+
+	test("should return UUID as-is even if repository does not exist in database", () => {
+		// UUID passthrough doesn't validate existence - this is by design
+		// for backward compatibility with existing workflows
+		const nonExistentUuid = "99999999-9999-9999-9999-999999999999";
+		const result = resolveRepositoryIdentifier(nonExistentUuid);
+		expect(result).toBe(nonExistentUuid);
+	});
+
+	test("should resolve full_name to UUID when repository exists", () => {
+		db.run(
+			"INSERT INTO repositories (id, name, full_name, default_branch) VALUES (?, ?, ?, ?)",
+			[testRepoId, "test-repo", testFullName, "main"],
+		);
+
+		const result = resolveRepositoryIdentifier(testFullName);
+		expect(result).toBe(testRepoId);
+	});
+
+	test("should resolve local full_name format", () => {
+		const localRepoId = randomUUID();
+		db.run(
+			"INSERT INTO repositories (id, name, full_name, default_branch) VALUES (?, ?, ?, ?)",
+			[localRepoId, "kotadb", "local/kotadb", "main"],
+		);
+
+		const result = resolveRepositoryIdentifier("local/kotadb");
+		expect(result).toBe(localRepoId);
+	});
+
+	test("should return null for non-existent full_name", () => {
+		const result = resolveRepositoryIdentifier("nonexistent/repo");
+		expect(result).toBeNull();
+	});
+
+	test("should be case-sensitive for full_name matching", () => {
+		db.run(
+			"INSERT INTO repositories (id, name, full_name, default_branch) VALUES (?, ?, ?, ?)",
+			[testRepoId, "test-repo", testFullName, "main"],
+		);
+
+		// Different case should not match
+		const result = resolveRepositoryIdentifier("TEST-OWNER/TEST-REPO");
+		expect(result).toBeNull();
+	});
+
+	test("should handle empty string as no repository provided", () => {
+		db.run(
+			"INSERT INTO repositories (id, name, full_name, default_branch) VALUES (?, ?, ?, ?)",
+			[testRepoId, "test-repo", testFullName, "main"],
+		);
+
+		// Empty string is falsy, should return first repository
+		const result = resolveRepositoryIdentifier("");
+		expect(result).toBe(testRepoId);
+	});
+});
+
+describe("resolveRepositoryParam (alias)", () => {
+	test("should be the same function as resolveRepositoryIdentifier", () => {
+		expect(resolveRepositoryIdentifier).toBe(resolveRepositoryParam);
+	});
+});
+
+describe("resolveRepositoryIdentifierWithError", () => {
+	let db: KotaDatabase;
+	let tempDir: string;
+	let dbPath: string;
+	let originalDbPath: string | undefined;
+	const testRepoId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+	const testFullName = "error-test-owner/error-test-repo";
+
+	beforeAll(() => {
+		tempDir = createTempDir("mcp-repo-resolver-error-test-");
+		dbPath = join(tempDir, "test.db");
+
+		originalDbPath = process.env.KOTADB_PATH;
+		process.env.KOTADB_PATH = dbPath;
+		closeGlobalConnections();
+	});
+
+	afterAll(() => {
+		if (originalDbPath !== undefined) {
+			process.env.KOTADB_PATH = originalDbPath;
+		} else {
+			delete process.env.KOTADB_PATH;
+		}
+		closeGlobalConnections();
+		cleanupTempDir(tempDir);
+	});
+
+	beforeEach(() => {
+		db = getGlobalDatabase();
+	});
+
+	afterEach(() => {
+		clearTestData(db);
+	});
+
+	test("should return error when no repositories exist and param is undefined", () => {
+		const result = resolveRepositoryIdentifierWithError(undefined);
+		expect("error" in result).toBe(true);
+		if ("error" in result) {
+			expect(result.error).toContain("No repositories found");
+			expect(result.error).toContain("index_repository");
+		}
+	});
+
+	test("should return id when repository exists and param is undefined", () => {
+		db.run(
+			"INSERT INTO repositories (id, name, full_name, default_branch) VALUES (?, ?, ?, ?)",
+			[testRepoId, "test-repo", testFullName, "main"],
+		);
+
+		const result = resolveRepositoryIdentifierWithError(undefined);
+		expect("id" in result).toBe(true);
+		if ("id" in result) {
+			expect(result.id).toBe(testRepoId);
+		}
+	});
+
+	test("should return id for valid UUID (passthrough without validation)", () => {
+		// UUID passthrough doesn't validate existence - by design
+		const inputUuid = randomUUID();
+		const result = resolveRepositoryIdentifierWithError(inputUuid);
+		expect("id" in result).toBe(true);
+		if ("id" in result) {
+			expect(result.id).toBe(inputUuid);
+		}
+	});
+
+	test("should return id for non-existent UUID (passthrough)", () => {
+		// UUID passthrough doesn't validate existence - this is by design
+		const nonExistentUuid = "99999999-9999-9999-9999-999999999999";
+		const result = resolveRepositoryIdentifierWithError(nonExistentUuid);
+		expect("id" in result).toBe(true);
+		if ("id" in result) {
+			expect(result.id).toBe(nonExistentUuid);
+		}
+	});
+
+	test("should return id when full_name resolves", () => {
+		db.run(
+			"INSERT INTO repositories (id, name, full_name, default_branch) VALUES (?, ?, ?, ?)",
+			[testRepoId, "test-repo", testFullName, "main"],
+		);
+
+		const result = resolveRepositoryIdentifierWithError(testFullName);
+		expect("id" in result).toBe(true);
+		if ("id" in result) {
+			expect(result.id).toBe(testRepoId);
+		}
+	});
+
+	test("should return error for non-existent full_name", () => {
+		const result = resolveRepositoryIdentifierWithError("nonexistent/repo");
+		expect("error" in result).toBe(true);
+		if ("error" in result) {
+			expect(result.error).toContain("Repository not found");
+			expect(result.error).toContain("nonexistent/repo");
+		}
+	});
+
+	test("should include repository name in error message", () => {
+		const result = resolveRepositoryIdentifierWithError("my-org/my-project");
+		expect("error" in result).toBe(true);
+		if ("error" in result) {
+			expect(result.error).toContain("my-org/my-project");
+		}
+	});
+});


### PR DESCRIPTION
## Summary

- Add repository identifier resolution that accepts both UUID and full_name formats
- Create shared `repository-resolver.ts` utility module
- Update `search_dependencies`, `analyze_change_impact`, and `validate_implementation_spec` MCP tools
- Add 29 comprehensive unit and integration tests

## Changes

### New Files
- `app/src/mcp/repository-resolver.ts` - Shared resolution utilities
- `app/tests/mcp/repository-resolver.test.ts` - Unit tests (29 tests)
- `app/tests/mcp/repository-resolver.integration.test.ts` - Integration tests

### Modified Files
- `app/src/mcp/tools.ts` - Use new resolver in `executeSearchDependencies`
- `app/src/mcp/impact-analysis.ts` - Replace local resolver with shared module
- `app/src/mcp/spec-validation.ts` - Replace local resolver with shared module

## Usage

Now MCP tools accept both formats:

```typescript
// UUID (still works - backward compatible)
mcp__kotadb-bunx__search_dependencies({
  file_path: "src/mcp/tools.ts",
  repository: "71fdd47f-8c7c-4823-93a0-1161b5f1372f"
})

// full_name (new! more user-friendly)
mcp__kotadb-bunx__search_dependencies({
  file_path: "src/mcp/tools.ts",
  repository: "local/kotadb"
})
```

## Test plan

- [x] TypeScript type check passes
- [x] All 29 new tests pass
- [x] All 169 MCP tests pass (3 pre-existing failures in search_code FTS5)
- [x] Backward compatibility verified (UUIDs still work)
- [x] Error messages for invalid repositories

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)