### PR TITLE
fix(cli): redirect all logging to stderr for clean JSON output

### DIFF
--- a/app/src/api/openapi/builder.ts
+++ b/app/src/api/openapi/builder.ts
@@ -184,7 +184,7 @@ Repository indexing and advanced code intelligence operations are available via 
 	const duration = Date.now() - startTime;
 	const pathCount = Object.keys(spec.paths || {}).length;
 
-	process.stdout.write(JSON.stringify({
+	process.stderr.write(JSON.stringify({
 		level: 'info',
 		module: 'openapi-builder',
 		message: 'OpenAPI spec generated',

--- a/app/src/instrument.ts
+++ b/app/src/instrument.ts
@@ -26,9 +26,6 @@ if (process.env.NODE_ENV !== "test") {
 			// Privacy compliance: don't send IP addresses or user agents automatically
 			sendDefaultPii: false,
 
-			// Enable debug mode in development
-			debug: isDevelopment,
-
 			// Scrub sensitive headers before sending to Sentry
 			beforeSend(event, hint) {
 				// Remove sensitive headers
@@ -61,7 +58,7 @@ if (process.env.NODE_ENV !== "test") {
 		});
 
 		if (isDevelopment && process.env.SENTRY_DSN) {
-			process.stdout.write(
+			process.stderr.write(
 				JSON.stringify({
 					timestamp: new Date().toISOString(),
 					level: "info",

--- a/app/src/logging/logger.ts
+++ b/app/src/logging/logger.ts
@@ -100,19 +100,12 @@ function maskSensitiveData(context: LogContext): LogContext {
 }
 
 /**
- * Format and write log entry to stdout (info/debug/warn) or stderr (error)
+ * Format and write log entry to stderr (all logs go to stderr to keep stdout clean for JSON output)
  */
-function writeLog(entry: LogEntry, forceStderr = false): void {
+function writeLog(entry: LogEntry, _forceStderr = false): void {
 	const json = JSON.stringify(entry);
-	const output = `${json}\n`;
-
-	if (forceStderr || entry.level === "error") {
-		process.stderr.write(output);
-	} else {
-		process.stdout.write(output);
-	}
+	process.stderr.write(`${json}\n`);
 }
-
 /**
  * Create a logger instance with optional correlation context
  */

--- a/app/tests/logging/middleware.test.ts
+++ b/app/tests/logging/middleware.test.ts
@@ -1,5 +1,8 @@
 /**
  * Integration tests for request logging middleware
+ * 
+ * Note: All log levels output to stderr to keep stdout clean for JSON output.
+ * This is intentional - see issue #117.
  */
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
@@ -10,7 +13,6 @@ import type { LogEntry } from "@logging/logger";
 
 describe("Request logging middleware", () => {
 	let app: Express;
-	let stdoutSpy: ReturnType<typeof mock>;
 	let stderrSpy: ReturnType<typeof mock>;
 	let originalLogLevel: string | undefined;
 
@@ -18,10 +20,8 @@ describe("Request logging middleware", () => {
 		// Create Express app
 		app = express();
 
-		// Capture stdout and stderr
-		stdoutSpy = mock(() => {});
+		// Capture stderr (all logs go to stderr now)
 		stderrSpy = mock(() => {});
-		process.stdout.write = stdoutSpy;
 		process.stderr.write = stderrSpy;
 
 		// Save original log level
@@ -75,8 +75,8 @@ describe("Request logging middleware", () => {
 			try {
 				await fetch(`http://localhost:${port}/test`);
 
-				// Check that logs contain request_id
-				const logs = stdoutSpy.mock.calls
+				// Check that logs contain request_id (all logs go to stderr)
+				const logs = stderrSpy.mock.calls
 					.map((call) => JSON.parse(call[0] as string) as LogEntry)
 					.filter((log) => log.message.includes("Incoming request"));
 
@@ -102,7 +102,7 @@ describe("Request logging middleware", () => {
 			try {
 				await fetch(`http://localhost:${port}/api/test`);
 
-				const logs = stdoutSpy.mock.calls
+				const logs = stderrSpy.mock.calls
 					.map((call) => JSON.parse(call[0] as string) as LogEntry)
 					.filter((log) => log.message === "Incoming request");
 
@@ -126,7 +126,7 @@ describe("Request logging middleware", () => {
 			try {
 				await fetch(`http://localhost:${port}/test`);
 
-				const logs = stdoutSpy.mock.calls
+				const logs = stderrSpy.mock.calls
 					.map((call) => JSON.parse(call[0] as string) as LogEntry)
 					.filter((log) => log.message === "Request completed");
 
@@ -150,7 +150,7 @@ describe("Request logging middleware", () => {
 			try {
 				await fetch(`http://localhost:${port}/test`);
 
-				const logs = stdoutSpy.mock.calls
+				const logs = stderrSpy.mock.calls
 					.map((call) => JSON.parse(call[0] as string) as LogEntry)
 					.filter((log) => log.level === "warn" && log.message.includes("Request completed"));
 
@@ -173,7 +173,7 @@ describe("Request logging middleware", () => {
 			try {
 				await fetch(`http://localhost:${port}/test`);
 
-				const logs = stdoutSpy.mock.calls
+				const logs = stderrSpy.mock.calls
 					.map((call) => JSON.parse(call[0] as string) as LogEntry)
 					.filter((log) => log.level === "warn" && log.message.includes("Request completed"));
 
@@ -219,7 +219,7 @@ describe("Request logging middleware", () => {
 			try {
 				await fetch(`http://localhost:${port}/test`);
 
-				const logs = stdoutSpy.mock.calls
+				const logs = stderrSpy.mock.calls
 					.map((call) => JSON.parse(call[0] as string) as LogEntry)
 					.filter((log) => log.message === "Custom handler log");
 


### PR DESCRIPTION
## Summary

- Fixes stdout pollution that breaks hook JSON parsing
- Removes Sentry debug mode (was outputting verbose logs to stdout)
- Redirects all logging to stderr (instrument.ts, logger.ts, openapi/builder.ts)
- Ensures `kotadb deps --format json` outputs only valid JSON

## Test plan

- [x] `kotadb deps --file X --format json 2>/dev/null | head -1` outputs `{`
- [x] Hook simulation parses JSON correctly
- [x] All 31 CLI tests pass

Fixes #117

🤖 Generated with [Claude Code](https://claude.ai/code)