### PR TITLE
feat(memory): add persistent memory layer for cross-session intelligence

### DIFF
--- a/app/src/db/migrations/004_memory_layer.sql
+++ b/app/src/db/migrations/004_memory_layer.sql
@@ -1,0 +1,183 @@
+-- SQLite Migration: Memory Layer Schema Extensions
+--
+-- Migration: 004_memory_layer
+-- Issue: Memory Layer for Agent Intelligence
+-- Author: Claude Code
+-- Date: 2026-02-03
+--
+-- This migration extends the memory layer tables with additional schema:
+-- - decisions: Add status column (active, superseded, deprecated)
+-- - failed_approaches: Alternative to failures with clearer naming
+-- - pattern_annotations: Enhanced patterns with evidence/confidence scoring
+-- - agent_sessions: Track agent work sessions
+-- - session_insights: Insights linked to sessions with file references
+--
+-- Note: The base sqlite-schema.sql already has decisions, failures, patterns,
+-- and insights tables. This migration adds enhanced versions and the missing
+-- agent_sessions table for complete session tracking.
+
+-- ============================================================================
+-- 1. Extend Decisions Table - Add status column
+-- ============================================================================
+-- Add status column to track decision lifecycle
+
+ALTER TABLE decisions ADD COLUMN status TEXT DEFAULT 'active';
+
+-- Add index for active decisions (most common query)
+CREATE INDEX IF NOT EXISTS idx_decisions_status ON decisions(status) WHERE status = 'active';
+
+-- ============================================================================
+-- 2. Failed Approaches Table (alternative to failures with clearer naming)
+-- ============================================================================
+-- Tracks what didn't work to prevent repeating mistakes
+
+CREATE TABLE IF NOT EXISTS failed_approaches (
+    id TEXT PRIMARY KEY,                         -- uuid → TEXT
+    repository_id TEXT NOT NULL,                 -- Foreign key to repositories
+    title TEXT NOT NULL,                         -- Short description
+    problem TEXT NOT NULL,                       -- What problem was being solved
+    approach TEXT NOT NULL,                      -- What was tried
+    failure_reason TEXT NOT NULL,                -- Why it failed
+    related_files TEXT,                          -- JSON array of related file paths
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    
+    FOREIGN KEY (repository_id) REFERENCES repositories(id) ON DELETE CASCADE
+);
+
+-- Indexes for common queries
+CREATE INDEX IF NOT EXISTS idx_failed_approaches_repository_id ON failed_approaches(repository_id);
+CREATE INDEX IF NOT EXISTS idx_failed_approaches_created_at ON failed_approaches(created_at DESC);
+
+-- ============================================================================
+-- 3. Failed Approaches FTS5 Virtual Table
+-- ============================================================================
+-- External content FTS5 for searching failed approaches
+
+CREATE VIRTUAL TABLE IF NOT EXISTS failed_approaches_fts USING fts5(
+    title,
+    problem,
+    approach,
+    failure_reason,
+    content='failed_approaches',
+    content_rowid='rowid'
+);
+
+-- ============================================================================
+-- 4. Failed Approaches FTS5 Sync Triggers
+-- ============================================================================
+
+-- After INSERT: Add new failed approach to FTS index
+CREATE TRIGGER IF NOT EXISTS failed_approaches_fts_ai 
+AFTER INSERT ON failed_approaches 
+BEGIN
+    INSERT INTO failed_approaches_fts(rowid, title, problem, approach, failure_reason) 
+    VALUES (new.rowid, new.title, new.problem, new.approach, new.failure_reason);
+END;
+
+-- After DELETE: Remove failed approach from FTS index
+CREATE TRIGGER IF NOT EXISTS failed_approaches_fts_ad 
+AFTER DELETE ON failed_approaches 
+BEGIN
+    INSERT INTO failed_approaches_fts(failed_approaches_fts, rowid, title, problem, approach, failure_reason) 
+    VALUES ('delete', old.rowid, old.title, old.problem, old.approach, old.failure_reason);
+END;
+
+-- After UPDATE: Update failed approach in FTS index (delete old, insert new)
+CREATE TRIGGER IF NOT EXISTS failed_approaches_fts_au 
+AFTER UPDATE ON failed_approaches 
+BEGIN
+    INSERT INTO failed_approaches_fts(failed_approaches_fts, rowid, title, problem, approach, failure_reason) 
+    VALUES ('delete', old.rowid, old.title, old.problem, old.approach, old.failure_reason);
+    INSERT INTO failed_approaches_fts(rowid, title, problem, approach, failure_reason) 
+    VALUES (new.rowid, new.title, new.problem, new.approach, new.failure_reason);
+END;
+
+-- ============================================================================
+-- 5. Pattern Annotations Table
+-- ============================================================================
+-- Enhanced pattern detection with evidence counting and confidence scoring
+
+CREATE TABLE IF NOT EXISTS pattern_annotations (
+    id TEXT PRIMARY KEY,                         -- uuid → TEXT
+    repository_id TEXT NOT NULL,                 -- Foreign key to repositories
+    pattern_type TEXT NOT NULL,                  -- Pattern category (logging, error-handling, testing, etc.)
+    pattern_name TEXT NOT NULL,                  -- Pattern identifier
+    description TEXT NOT NULL,                   -- Human-readable description
+    example_code TEXT,                           -- Code example (optional)
+    evidence_count INTEGER NOT NULL DEFAULT 1,   -- Number of occurrences found
+    confidence REAL NOT NULL DEFAULT 1.0,        -- Confidence score (0.0-1.0)
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    
+    FOREIGN KEY (repository_id) REFERENCES repositories(id) ON DELETE CASCADE,
+    
+    CHECK (confidence >= 0.0 AND confidence <= 1.0),
+    CHECK (evidence_count >= 1)
+);
+
+-- Indexes for common queries
+CREATE INDEX IF NOT EXISTS idx_pattern_annotations_repository_id ON pattern_annotations(repository_id);
+CREATE INDEX IF NOT EXISTS idx_pattern_annotations_pattern_type ON pattern_annotations(pattern_type);
+CREATE INDEX IF NOT EXISTS idx_pattern_annotations_confidence ON pattern_annotations(confidence DESC);
+-- Composite index for high-confidence patterns by type
+CREATE INDEX IF NOT EXISTS idx_pattern_annotations_type_confidence 
+ON pattern_annotations(repository_id, pattern_type, confidence DESC);
+
+-- ============================================================================
+-- 6. Agent Sessions Table
+-- ============================================================================
+-- Tracks agent work sessions for learning and analysis
+
+CREATE TABLE IF NOT EXISTS agent_sessions (
+    id TEXT PRIMARY KEY,                         -- uuid → TEXT
+    repository_id TEXT NOT NULL,                 -- Foreign key to repositories
+    agent_type TEXT,                             -- Type of agent (plan, build, improve, etc.)
+    task_summary TEXT,                           -- What the agent was working on
+    outcome TEXT,                                -- Session outcome
+    files_modified TEXT,                         -- JSON array of modified file paths
+    started_at TEXT NOT NULL DEFAULT (datetime('now')),
+    ended_at TEXT,                               -- NULL if session is ongoing
+    
+    FOREIGN KEY (repository_id) REFERENCES repositories(id) ON DELETE CASCADE,
+    
+    CHECK (outcome IS NULL OR outcome IN ('success', 'failure', 'partial'))
+);
+
+-- Indexes for common queries
+CREATE INDEX IF NOT EXISTS idx_agent_sessions_repository_id ON agent_sessions(repository_id);
+CREATE INDEX IF NOT EXISTS idx_agent_sessions_agent_type ON agent_sessions(agent_type) WHERE agent_type IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_agent_sessions_outcome ON agent_sessions(outcome) WHERE outcome IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_agent_sessions_started_at ON agent_sessions(started_at DESC);
+-- Partial index for ongoing sessions
+CREATE INDEX IF NOT EXISTS idx_agent_sessions_ongoing ON agent_sessions(repository_id) WHERE ended_at IS NULL;
+
+-- ============================================================================
+-- 7. Session Insights Table
+-- ============================================================================
+-- Insights discovered during agent sessions with proper foreign keys
+
+CREATE TABLE IF NOT EXISTS session_insights (
+    id TEXT PRIMARY KEY,                         -- uuid → TEXT
+    session_id TEXT NOT NULL,                    -- Foreign key to agent_sessions
+    insight_type TEXT NOT NULL,                  -- Type of insight
+    content TEXT NOT NULL,                       -- The insight content
+    related_file_id TEXT,                        -- Optional reference to indexed_files
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    
+    FOREIGN KEY (session_id) REFERENCES agent_sessions(id) ON DELETE CASCADE,
+    FOREIGN KEY (related_file_id) REFERENCES indexed_files(id) ON DELETE SET NULL,
+    
+    CHECK (insight_type IN ('discovery', 'failure', 'workaround'))
+);
+
+-- Indexes for common queries
+CREATE INDEX IF NOT EXISTS idx_session_insights_session_id ON session_insights(session_id);
+CREATE INDEX IF NOT EXISTS idx_session_insights_insight_type ON session_insights(insight_type);
+CREATE INDEX IF NOT EXISTS idx_session_insights_related_file ON session_insights(related_file_id) 
+WHERE related_file_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_session_insights_created_at ON session_insights(created_at DESC);
+
+-- ============================================================================
+-- 8. Record Migration
+-- ============================================================================
+
+INSERT OR IGNORE INTO schema_migrations (name) VALUES ('004_memory_layer');

--- a/app/src/db/sqlite/__tests__/schema-validation.test.ts
+++ b/app/src/db/sqlite/__tests__/schema-validation.test.ts
@@ -663,8 +663,8 @@ describe("SQLite Schema Validation", () => {
 		});
 
 		it("should auto-increment id", () => {
-			db.run("INSERT INTO schema_migrations (name) VALUES (?)", ["002_test_migration"]);
-			db.run("INSERT INTO schema_migrations (name) VALUES (?)", ["003_another_migration"]);
+			db.run("INSERT INTO schema_migrations (name) VALUES (?)", ["003_test_migration"]);
+			db.run("INSERT INTO schema_migrations (name) VALUES (?)", ["004_another_migration"]);
 
 			const migrations = db
 				.query<{ id: number; name: string }, []>(
@@ -672,10 +672,11 @@ describe("SQLite Schema Validation", () => {
 				)
 				.all();
 
-			expect(migrations.length).toBe(3); // Including initial migration
-			expect(migrations[0]?.id).toBe(1);
-			expect(migrations[1]?.id).toBe(2);
-			expect(migrations[2]?.id).toBe(3);
+			expect(migrations.length).toBe(4); // 001_initial + 002_memory_layer + test migrations
+			expect(migrations[0]?.id).toBe(1); // 001_initial_sqlite_schema
+			expect(migrations[1]?.id).toBe(2); // 002_memory_layer_tables
+			expect(migrations[2]?.id).toBe(3); // 003_test_migration
+			expect(migrations[3]?.id).toBe(4); // 004_another_migration
 		});
 	});
 

--- a/app/src/mcp/server.ts
+++ b/app/src/mcp/server.ts
@@ -23,6 +23,14 @@ import {
 	SYNC_EXPORT_TOOL,
 	SYNC_IMPORT_TOOL,
 	VALIDATE_IMPLEMENTATION_SPEC_TOOL,
+	// Memory Layer tools
+	SEARCH_DECISIONS_TOOL,
+	RECORD_DECISION_TOOL,
+	SEARCH_FAILURES_TOOL,
+	RECORD_FAILURE_TOOL,
+	SEARCH_PATTERNS_TOOL,
+	RECORD_INSIGHT_TOOL,
+	// Execute functions
 	executeAnalyzeChangeImpact,
 	executeGenerateTaskContext,
 	executeIndexRepository,
@@ -32,6 +40,13 @@ import {
 	executeSyncExport,
 	executeSyncImport,
 	executeValidateImplementationSpec,
+	// Memory Layer execute functions
+	executeSearchDecisions,
+	executeRecordDecision,
+	executeSearchFailures,
+	executeRecordFailure,
+	executeSearchPatterns,
+	executeRecordInsight,
 } from "./tools";
 
 const logger = createLogger({ module: "mcp-server" });
@@ -58,6 +73,12 @@ export interface McpServerContext {
  * - kota_sync_export: Export SQLite to JSONL
  * - kota_sync_import: Import JSONL to SQLite
  * - generate_task_context: Generate context for hook-based seeding
+ * - search_decisions: Search past architectural decisions
+ * - record_decision: Record a new architectural decision
+ * - search_failures: Search failed approaches
+ * - record_failure: Record a failed approach
+ * - search_patterns: Find codebase patterns
+ * - record_insight: Store a session insight
  */
 export function createMcpServer(context: McpServerContext): Server {
 	const server = new Server(
@@ -85,6 +106,13 @@ export function createMcpServer(context: McpServerContext): Server {
 				SYNC_EXPORT_TOOL,
 				SYNC_IMPORT_TOOL,
 				GENERATE_TASK_CONTEXT_TOOL,
+				// Memory Layer tools
+				SEARCH_DECISIONS_TOOL,
+				RECORD_DECISION_TOOL,
+				SEARCH_FAILURES_TOOL,
+				RECORD_FAILURE_TOOL,
+				SEARCH_PATTERNS_TOOL,
+				RECORD_INSIGHT_TOOL,
 			],
 		};
 	});
@@ -149,6 +177,49 @@ export function createMcpServer(context: McpServerContext): Server {
 					break;
 				case "generate_task_context":
 					result = await executeGenerateTaskContext(
+						toolArgs,
+						"", // requestId not used
+						context.userId,
+					);
+					break;
+				// Memory Layer tools
+				case "search_decisions":
+					result = await executeSearchDecisions(
+						toolArgs,
+						"", // requestId not used
+						context.userId,
+					);
+					break;
+				case "record_decision":
+					result = await executeRecordDecision(
+						toolArgs,
+						"", // requestId not used
+						context.userId,
+					);
+					break;
+				case "search_failures":
+					result = await executeSearchFailures(
+						toolArgs,
+						"", // requestId not used
+						context.userId,
+					);
+					break;
+				case "record_failure":
+					result = await executeRecordFailure(
+						toolArgs,
+						"", // requestId not used
+						context.userId,
+					);
+					break;
+				case "search_patterns":
+					result = await executeSearchPatterns(
+						toolArgs,
+						"", // requestId not used
+						context.userId,
+					);
+					break;
+				case "record_insight":
+					result = await executeRecordInsight(
 						toolArgs,
 						"", // requestId not used
 						context.userId,

--- a/app/src/mcp/tools.ts
+++ b/app/src/mcp/tools.ts
@@ -372,6 +372,230 @@ export const GENERATE_TASK_CONTEXT_TOOL: ToolDefinition = {
 	},
 };
 
+// ============================================================================
+// Memory Layer Tool Definitions
+// ============================================================================
+
+/**
+ * Tool: search_decisions
+ */
+export const SEARCH_DECISIONS_TOOL: ToolDefinition = {
+	name: "search_decisions",
+	description:
+		"Search past architectural decisions using FTS5. Returns decisions with relevance scores.",
+	inputSchema: {
+		type: "object",
+		properties: {
+			query: {
+				type: "string",
+				description: "Search query for decisions",
+			},
+			scope: {
+				type: "string",
+				enum: ["architecture", "pattern", "convention", "workaround"],
+				description: "Optional: Filter by decision scope",
+			},
+			repository: {
+				type: "string",
+				description: "Optional: Filter to a specific repository ID or full_name",
+			},
+			limit: {
+				type: "number",
+				description: "Optional: Max results (default: 20)",
+			},
+		},
+		required: ["query"],
+	},
+};
+
+/**
+ * Tool: record_decision
+ */
+export const RECORD_DECISION_TOOL: ToolDefinition = {
+	name: "record_decision",
+	description:
+		"Record a new architectural decision for future reference. Decisions are searchable via search_decisions.",
+	inputSchema: {
+		type: "object",
+		properties: {
+			title: {
+				type: "string",
+				description: "Decision title/summary",
+			},
+			context: {
+				type: "string",
+				description: "Context and background for the decision",
+			},
+			decision: {
+				type: "string",
+				description: "The actual decision made",
+			},
+			scope: {
+				type: "string",
+				enum: ["architecture", "pattern", "convention", "workaround"],
+				description: "Decision scope/category (default: pattern)",
+			},
+			rationale: {
+				type: "string",
+				description: "Optional: Why this decision was made",
+			},
+			alternatives: {
+				type: "array",
+				items: { type: "string" },
+				description: "Optional: Alternatives that were considered",
+			},
+			related_files: {
+				type: "array",
+				items: { type: "string" },
+				description: "Optional: Related file paths",
+			},
+			repository: {
+				type: "string",
+				description: "Optional: Repository ID or full_name",
+			},
+		},
+		required: ["title", "context", "decision"],
+	},
+};
+
+/**
+ * Tool: search_failures
+ */
+export const SEARCH_FAILURES_TOOL: ToolDefinition = {
+	name: "search_failures",
+	description:
+		"Search failed approaches to avoid repeating mistakes. Returns failures with relevance scores.",
+	inputSchema: {
+		type: "object",
+		properties: {
+			query: {
+				type: "string",
+				description: "Search query for failures",
+			},
+			repository: {
+				type: "string",
+				description: "Optional: Filter to a specific repository ID or full_name",
+			},
+			limit: {
+				type: "number",
+				description: "Optional: Max results (default: 20)",
+			},
+		},
+		required: ["query"],
+	},
+};
+
+/**
+ * Tool: record_failure
+ */
+export const RECORD_FAILURE_TOOL: ToolDefinition = {
+	name: "record_failure",
+	description:
+		"Record a failed approach for future reference. Helps agents avoid repeating mistakes.",
+	inputSchema: {
+		type: "object",
+		properties: {
+			title: {
+				type: "string",
+				description: "Failure title/summary",
+			},
+			problem: {
+				type: "string",
+				description: "The problem being solved",
+			},
+			approach: {
+				type: "string",
+				description: "The approach that was tried",
+			},
+			failure_reason: {
+				type: "string",
+				description: "Why the approach failed",
+			},
+			related_files: {
+				type: "array",
+				items: { type: "string" },
+				description: "Optional: Related file paths",
+			},
+			repository: {
+				type: "string",
+				description: "Optional: Repository ID or full_name",
+			},
+		},
+		required: ["title", "problem", "approach", "failure_reason"],
+	},
+};
+
+/**
+ * Tool: search_patterns
+ */
+export const SEARCH_PATTERNS_TOOL: ToolDefinition = {
+	name: "search_patterns",
+	description:
+		"Find codebase patterns by type or file. Returns discovered patterns for consistency.",
+	inputSchema: {
+		type: "object",
+		properties: {
+			query: {
+				type: "string",
+				description: "Optional: Search query for pattern name/description",
+			},
+			pattern_type: {
+				type: "string",
+				description: "Optional: Filter by pattern type (e.g., error-handling, api-call)",
+			},
+			file: {
+				type: "string",
+				description: "Optional: Filter by file path",
+			},
+			repository: {
+				type: "string",
+				description: "Optional: Filter to a specific repository ID or full_name",
+			},
+			limit: {
+				type: "number",
+				description: "Optional: Max results (default: 20)",
+			},
+		},
+	},
+};
+
+/**
+ * Tool: record_insight
+ */
+export const RECORD_INSIGHT_TOOL: ToolDefinition = {
+	name: "record_insight",
+	description:
+		"Store a session insight for future agents. Insights are discoveries, failures, or workarounds.",
+	inputSchema: {
+		type: "object",
+		properties: {
+			content: {
+				type: "string",
+				description: "The insight content",
+			},
+			insight_type: {
+				type: "string",
+				enum: ["discovery", "failure", "workaround"],
+				description: "Type of insight",
+			},
+			session_id: {
+				type: "string",
+				description: "Optional: Session identifier for grouping",
+			},
+			related_file: {
+				type: "string",
+				description: "Optional: Related file path",
+			},
+			repository: {
+				type: "string",
+				description: "Optional: Repository ID or full_name",
+			},
+		},
+		required: ["content", "insight_type"],
+	},
+};
+
+
 /**
  * Get all available tool definitions
  */
@@ -386,6 +610,13 @@ export function getToolDefinitions(): ToolDefinition[] {
 		SYNC_EXPORT_TOOL,
 		SYNC_IMPORT_TOOL,
 		GENERATE_TASK_CONTEXT_TOOL,
+		// Memory Layer tools
+		SEARCH_DECISIONS_TOOL,
+		RECORD_DECISION_TOOL,
+		SEARCH_FAILURES_TOOL,
+		RECORD_FAILURE_TOOL,
+		SEARCH_PATTERNS_TOOL,
+		RECORD_INSIGHT_TOOL,
 	];
 }
 
@@ -1131,6 +1362,520 @@ function generateTestFilePatterns(sourcePath: string): string[] {
 	return patterns;
 }
 
+
+
+// ============================================================================
+// Memory Layer Tool Executors
+// ============================================================================
+
+/**
+ * Escape a term for FTS5 MATCH clause
+ */
+function escapeFts5Term(term: string): string {
+	const escaped = term.replace(/"/g, '""');
+	return `"${escaped}"`;
+}
+
+/**
+ * Execute search_decisions tool
+ */
+export async function executeSearchDecisions(
+	params: unknown,
+	_requestId: string | number,
+	_userId: string,
+): Promise<unknown> {
+	if (typeof params !== "object" || params === null) {
+		throw new Error("Parameters must be an object");
+	}
+
+	const p = params as Record<string, unknown>;
+
+	if (p.query === undefined) {
+		throw new Error("Missing required parameter: query");
+	}
+	if (typeof p.query !== "string") {
+		throw new Error("Parameter 'query' must be a string");
+	}
+
+	if (p.scope !== undefined && typeof p.scope !== "string") {
+		throw new Error("Parameter 'scope' must be a string");
+	}
+	if (p.scope !== undefined && !["architecture", "pattern", "convention", "workaround"].includes(p.scope as string)) {
+		throw new Error("Parameter 'scope' must be one of: architecture, pattern, convention, workaround");
+	}
+	if (p.repository !== undefined && typeof p.repository !== "string") {
+		throw new Error("Parameter 'repository' must be a string");
+	}
+	if (p.limit !== undefined && typeof p.limit !== "number") {
+		throw new Error("Parameter 'limit' must be a number");
+	}
+
+	const db = getGlobalDatabase();
+	const escapedQuery = escapeFts5Term(p.query as string);
+	const limit = Math.min(Math.max((p.limit as number) || 20, 1), 100);
+
+	let sql = `
+		SELECT 
+			d.id,
+			d.title,
+			d.context,
+			d.decision,
+			d.scope,
+			d.rationale,
+			d.alternatives,
+			d.related_files,
+			d.repository_id,
+			d.created_at,
+			bm25(decisions_fts) as relevance
+		FROM decisions_fts
+		JOIN decisions d ON decisions_fts.rowid = d.rowid
+		WHERE decisions_fts MATCH ?
+	`;
+	const queryParams: (string | number)[] = [escapedQuery];
+
+	if (p.scope) {
+		sql += " AND d.scope = ?";
+		queryParams.push(p.scope as string);
+	}
+
+	if (p.repository) {
+		const repoResult = resolveRepositoryIdentifierWithError(p.repository as string);
+		if (!("error" in repoResult)) {
+			sql += " AND d.repository_id = ?";
+			queryParams.push(repoResult.id);
+		}
+	}
+
+	sql += " ORDER BY relevance LIMIT ?";
+	queryParams.push(limit);
+
+	const rows = db.query<{
+		id: string;
+		title: string;
+		context: string;
+		decision: string;
+		scope: string;
+		rationale: string | null;
+		alternatives: string;
+		related_files: string;
+		repository_id: string | null;
+		created_at: string;
+		relevance: number;
+	}>(sql, queryParams);
+
+	return {
+		results: rows.map((row) => ({
+			id: row.id,
+			title: row.title,
+			context: row.context,
+			decision: row.decision,
+			scope: row.scope,
+			rationale: row.rationale,
+			alternatives: JSON.parse(row.alternatives || "[]"),
+			related_files: JSON.parse(row.related_files || "[]"),
+			repository_id: row.repository_id,
+			created_at: row.created_at,
+			relevance: Math.abs(row.relevance),
+		})),
+		count: rows.length,
+	};
+}
+
+/**
+ * Execute record_decision tool
+ */
+export async function executeRecordDecision(
+	params: unknown,
+	_requestId: string | number,
+	_userId: string,
+): Promise<unknown> {
+	if (typeof params !== "object" || params === null) {
+		throw new Error("Parameters must be an object");
+	}
+
+	const p = params as Record<string, unknown>;
+
+	if (p.title === undefined || typeof p.title !== "string") {
+		throw new Error("Missing or invalid required parameter: title");
+	}
+	if (p.context === undefined || typeof p.context !== "string") {
+		throw new Error("Missing or invalid required parameter: context");
+	}
+	if (p.decision === undefined || typeof p.decision !== "string") {
+		throw new Error("Missing or invalid required parameter: decision");
+	}
+
+	const scope = (p.scope as string) || "pattern";
+	if (!["architecture", "pattern", "convention", "workaround"].includes(scope)) {
+		throw new Error("Parameter 'scope' must be one of: architecture, pattern, convention, workaround");
+	}
+
+	if (p.rationale !== undefined && typeof p.rationale !== "string") {
+		throw new Error("Parameter 'rationale' must be a string");
+	}
+	if (p.alternatives !== undefined && !Array.isArray(p.alternatives)) {
+		throw new Error("Parameter 'alternatives' must be an array");
+	}
+	if (p.related_files !== undefined && !Array.isArray(p.related_files)) {
+		throw new Error("Parameter 'related_files' must be an array");
+	}
+	if (p.repository !== undefined && typeof p.repository !== "string") {
+		throw new Error("Parameter 'repository' must be a string");
+	}
+
+	const db = getGlobalDatabase();
+	const { randomUUID } = await import("node:crypto");
+	const id = randomUUID();
+
+	let repositoryId: string | null = null;
+	if (p.repository) {
+		const repoResult = resolveRepositoryIdentifierWithError(p.repository as string);
+		if (!("error" in repoResult)) {
+			repositoryId = repoResult.id;
+		}
+	}
+
+	const sql = `
+		INSERT INTO decisions (
+			id, repository_id, title, context, decision, scope,
+			rationale, alternatives, related_files, created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))
+	`;
+
+	db.run(sql, [
+		id,
+		repositoryId,
+		p.title as string,
+		p.context as string,
+		p.decision as string,
+		scope,
+		(p.rationale as string) || null,
+		JSON.stringify((p.alternatives as string[]) || []),
+		JSON.stringify((p.related_files as string[]) || []),
+	]);
+
+	logger.info("Decision recorded", { id, title: p.title, scope });
+
+	return {
+		success: true,
+		id,
+		message: "Decision recorded successfully",
+	};
+}
+
+/**
+ * Execute search_failures tool
+ */
+export async function executeSearchFailures(
+	params: unknown,
+	_requestId: string | number,
+	_userId: string,
+): Promise<unknown> {
+	if (typeof params !== "object" || params === null) {
+		throw new Error("Parameters must be an object");
+	}
+
+	const p = params as Record<string, unknown>;
+
+	if (p.query === undefined) {
+		throw new Error("Missing required parameter: query");
+	}
+	if (typeof p.query !== "string") {
+		throw new Error("Parameter 'query' must be a string");
+	}
+
+	if (p.repository !== undefined && typeof p.repository !== "string") {
+		throw new Error("Parameter 'repository' must be a string");
+	}
+	if (p.limit !== undefined && typeof p.limit !== "number") {
+		throw new Error("Parameter 'limit' must be a number");
+	}
+
+	const db = getGlobalDatabase();
+	const escapedQuery = escapeFts5Term(p.query as string);
+	const limit = Math.min(Math.max((p.limit as number) || 20, 1), 100);
+
+	let sql = `
+		SELECT 
+			f.id,
+			f.title,
+			f.problem,
+			f.approach,
+			f.failure_reason,
+			f.related_files,
+			f.repository_id,
+			f.created_at,
+			bm25(failures_fts) as relevance
+		FROM failures_fts
+		JOIN failures f ON failures_fts.rowid = f.rowid
+		WHERE failures_fts MATCH ?
+	`;
+	const queryParams: (string | number)[] = [escapedQuery];
+
+	if (p.repository) {
+		const repoResult = resolveRepositoryIdentifierWithError(p.repository as string);
+		if (!("error" in repoResult)) {
+			sql += " AND f.repository_id = ?";
+			queryParams.push(repoResult.id);
+		}
+	}
+
+	sql += " ORDER BY relevance LIMIT ?";
+	queryParams.push(limit);
+
+	const rows = db.query<{
+		id: string;
+		title: string;
+		problem: string;
+		approach: string;
+		failure_reason: string;
+		related_files: string;
+		repository_id: string | null;
+		created_at: string;
+		relevance: number;
+	}>(sql, queryParams);
+
+	return {
+		results: rows.map((row) => ({
+			id: row.id,
+			title: row.title,
+			problem: row.problem,
+			approach: row.approach,
+			failure_reason: row.failure_reason,
+			related_files: JSON.parse(row.related_files || "[]"),
+			repository_id: row.repository_id,
+			created_at: row.created_at,
+			relevance: Math.abs(row.relevance),
+		})),
+		count: rows.length,
+	};
+}
+
+/**
+ * Execute record_failure tool
+ */
+export async function executeRecordFailure(
+	params: unknown,
+	_requestId: string | number,
+	_userId: string,
+): Promise<unknown> {
+	if (typeof params !== "object" || params === null) {
+		throw new Error("Parameters must be an object");
+	}
+
+	const p = params as Record<string, unknown>;
+
+	if (p.title === undefined || typeof p.title !== "string") {
+		throw new Error("Missing or invalid required parameter: title");
+	}
+	if (p.problem === undefined || typeof p.problem !== "string") {
+		throw new Error("Missing or invalid required parameter: problem");
+	}
+	if (p.approach === undefined || typeof p.approach !== "string") {
+		throw new Error("Missing or invalid required parameter: approach");
+	}
+	if (p.failure_reason === undefined || typeof p.failure_reason !== "string") {
+		throw new Error("Missing or invalid required parameter: failure_reason");
+	}
+
+	if (p.related_files !== undefined && !Array.isArray(p.related_files)) {
+		throw new Error("Parameter 'related_files' must be an array");
+	}
+	if (p.repository !== undefined && typeof p.repository !== "string") {
+		throw new Error("Parameter 'repository' must be a string");
+	}
+
+	const db = getGlobalDatabase();
+	const { randomUUID } = await import("node:crypto");
+	const id = randomUUID();
+
+	let repositoryId: string | null = null;
+	if (p.repository) {
+		const repoResult = resolveRepositoryIdentifierWithError(p.repository as string);
+		if (!("error" in repoResult)) {
+			repositoryId = repoResult.id;
+		}
+	}
+
+	const sql = `
+		INSERT INTO failures (
+			id, repository_id, title, problem, approach, failure_reason,
+			related_files, created_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))
+	`;
+
+	db.run(sql, [
+		id,
+		repositoryId,
+		p.title as string,
+		p.problem as string,
+		p.approach as string,
+		p.failure_reason as string,
+		JSON.stringify((p.related_files as string[]) || []),
+	]);
+
+	logger.info("Failure recorded", { id, title: p.title });
+
+	return {
+		success: true,
+		id,
+		message: "Failure recorded successfully",
+	};
+}
+
+/**
+ * Execute search_patterns tool
+ */
+export async function executeSearchPatterns(
+	params: unknown,
+	_requestId: string | number,
+	_userId: string,
+): Promise<unknown> {
+	if (params !== undefined && (typeof params !== "object" || params === null)) {
+		throw new Error("Parameters must be an object");
+	}
+
+	const p = (params as Record<string, unknown>) || {};
+
+	if (p.query !== undefined && typeof p.query !== "string") {
+		throw new Error("Parameter 'query' must be a string");
+	}
+	if (p.pattern_type !== undefined && typeof p.pattern_type !== "string") {
+		throw new Error("Parameter 'pattern_type' must be a string");
+	}
+	if (p.file !== undefined && typeof p.file !== "string") {
+		throw new Error("Parameter 'file' must be a string");
+	}
+	if (p.repository !== undefined && typeof p.repository !== "string") {
+		throw new Error("Parameter 'repository' must be a string");
+	}
+	if (p.limit !== undefined && typeof p.limit !== "number") {
+		throw new Error("Parameter 'limit' must be a number");
+	}
+
+	const db = getGlobalDatabase();
+	const limit = Math.min(Math.max((p.limit as number) || 20, 1), 100);
+
+	let sql = `
+		SELECT 
+			id,
+			repository_id,
+			pattern_type,
+			file_path,
+			description,
+			example,
+			created_at
+		FROM patterns
+		WHERE 1=1
+	`;
+	const queryParams: (string | number)[] = [];
+
+	if (p.pattern_type) {
+		sql += " AND pattern_type = ?";
+		queryParams.push(p.pattern_type as string);
+	}
+
+	if (p.file) {
+		sql += " AND file_path = ?";
+		queryParams.push(p.file as string);
+	}
+
+	if (p.repository) {
+		const repoResult = resolveRepositoryIdentifierWithError(p.repository as string);
+		if (!("error" in repoResult)) {
+			sql += " AND repository_id = ?";
+			queryParams.push(repoResult.id);
+		}
+	}
+
+	sql += " ORDER BY created_at DESC LIMIT ?";
+	queryParams.push(limit);
+
+	const rows = db.query<{
+		id: string;
+		repository_id: string | null;
+		pattern_type: string;
+		file_path: string | null;
+		description: string;
+		example: string | null;
+		created_at: string;
+	}>(sql, queryParams);
+
+	return {
+		results: rows.map((row) => ({
+			id: row.id,
+			repository_id: row.repository_id,
+			pattern_type: row.pattern_type,
+			file_path: row.file_path,
+			description: row.description,
+			example: row.example,
+			created_at: row.created_at,
+		})),
+		count: rows.length,
+	};
+}
+
+/**
+ * Execute record_insight tool
+ */
+export async function executeRecordInsight(
+	params: unknown,
+	_requestId: string | number,
+	_userId: string,
+): Promise<unknown> {
+	if (typeof params !== "object" || params === null) {
+		throw new Error("Parameters must be an object");
+	}
+
+	const p = params as Record<string, unknown>;
+
+	if (p.content === undefined || typeof p.content !== "string") {
+		throw new Error("Missing or invalid required parameter: content");
+	}
+	if (p.insight_type === undefined || typeof p.insight_type !== "string") {
+		throw new Error("Missing or invalid required parameter: insight_type");
+	}
+	if (!["discovery", "failure", "workaround"].includes(p.insight_type as string)) {
+		throw new Error("Parameter 'insight_type' must be one of: discovery, failure, workaround");
+	}
+
+	if (p.session_id !== undefined && typeof p.session_id !== "string") {
+		throw new Error("Parameter 'session_id' must be a string");
+	}
+	if (p.related_file !== undefined && typeof p.related_file !== "string") {
+		throw new Error("Parameter 'related_file' must be a string");
+	}
+	if (p.repository !== undefined && typeof p.repository !== "string") {
+		throw new Error("Parameter 'repository' must be a string");
+	}
+
+	const db = getGlobalDatabase();
+	const { randomUUID } = await import("node:crypto");
+	const id = randomUUID();
+
+	const sql = `
+		INSERT INTO insights (
+			id, session_id, content, insight_type, related_file, created_at
+		) VALUES (?, ?, ?, ?, ?, datetime('now'))
+	`;
+
+	db.run(sql, [
+		id,
+		(p.session_id as string) || null,
+		p.content as string,
+		p.insight_type as string,
+		(p.related_file as string) || null,
+	]);
+
+	logger.info("Insight recorded", { id, insight_type: p.insight_type });
+
+	return {
+		success: true,
+		id,
+		message: "Insight recorded successfully",
+	};
+}
+
 /**
  * Main tool call dispatcher
  */
@@ -1159,6 +1904,19 @@ export async function handleToolCall(
 			return await executeSyncImport(params, requestId);
 		case "generate_task_context":
 			return await executeGenerateTaskContext(params, requestId, userId);
+		// Memory Layer tools
+		case "search_decisions":
+			return await executeSearchDecisions(params, requestId, userId);
+		case "record_decision":
+			return await executeRecordDecision(params, requestId, userId);
+		case "search_failures":
+			return await executeSearchFailures(params, requestId, userId);
+		case "record_failure":
+			return await executeRecordFailure(params, requestId, userId);
+		case "search_patterns":
+			return await executeSearchPatterns(params, requestId, userId);
+		case "record_insight":
+			return await executeRecordInsight(params, requestId, userId);
 		default:
 			throw invalidParams(requestId, "Unknown tool: " + toolName);
 	}

--- a/app/tests/mcp/memory-tools.test.ts
+++ b/app/tests/mcp/memory-tools.test.ts
@@ -1,0 +1,798 @@
+/**
+ * Tests for Memory Layer MCP tools
+ *
+ * Following antimocking philosophy: uses real in-memory SQLite databases
+ *
+ * Test Coverage:
+ * - search_decisions: FTS5 decision search with filtering
+ * - record_decision: Record architectural decisions
+ * - search_failures: FTS5 failure search
+ * - record_failure: Record failed approaches
+ * - search_patterns: Pattern search by type
+ * - record_insight: Store session insights
+ *
+ * @module tests/mcp/memory-tools
+ */
+
+import { describe, expect, test, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import {
+	executeSearchDecisions,
+	executeRecordDecision,
+	executeSearchFailures,
+	executeRecordFailure,
+	executeSearchPatterns,
+	executeRecordInsight,
+} from "@mcp/tools.js";
+import { closeGlobalConnections, getGlobalDatabase } from "@db/sqlite/index.js";
+import type { KotaDatabase } from "@db/sqlite/index.js";
+import { createTempDir, cleanupTempDir, clearTestData, createTestRepository } from "../helpers/db.js";
+
+describe("Memory Layer MCP Tools", () => {
+	let db: KotaDatabase;
+	let tempDir: string;
+	let dbPath: string;
+	let originalDbPath: string | undefined;
+	let testRepoId: string;
+	const requestId = "test-request-1";
+	const userId = "test-user-1";
+
+	beforeAll(() => {
+		// Create temp directory and set KOTADB_PATH for test isolation
+		tempDir = createTempDir("mcp-memory-tools-test-");
+		dbPath = join(tempDir, "test.db");
+
+		originalDbPath = process.env.KOTADB_PATH;
+		process.env.KOTADB_PATH = dbPath;
+		closeGlobalConnections();
+	});
+
+	afterAll(() => {
+		// Restore original KOTADB_PATH
+		if (originalDbPath !== undefined) {
+			process.env.KOTADB_PATH = originalDbPath;
+		} else {
+			delete process.env.KOTADB_PATH;
+		}
+		closeGlobalConnections();
+		cleanupTempDir(tempDir);
+	});
+
+	beforeEach(() => {
+		db = getGlobalDatabase();
+		// Create test repository
+		const repo = createTestRepository(db, {
+			name: "memory-test-repo",
+			fullName: "test/memory-test-repo",
+		});
+		testRepoId = repo.id;
+	});
+
+	afterEach(() => {
+		clearTestData(db);
+		// Clear memory layer tables
+		db.run("DELETE FROM insights");
+		db.run("DELETE FROM patterns");
+		db.run("DELETE FROM failures");
+		db.run("DELETE FROM decisions");
+	});
+
+	// ============================================================================
+	// Decision Recording & Search
+	// ============================================================================
+
+	describe("record_decision", () => {
+		test("should record decision with all fields", async () => {
+			const params = {
+				title: "Use SQLite for local storage",
+				context: "Need fast local database with FTS5 support",
+				decision: "Use SQLite with FTS5 for code search",
+				scope: "architecture",
+				rationale: "SQLite provides excellent performance and native FTS5",
+				alternatives: ["PostgreSQL with pg_trgm", "Elasticsearch"],
+				related_files: ["src/db/sqlite/index.ts", "src/db/schema.sql"],
+				repository: testRepoId,
+			};
+
+			const result = await executeRecordDecision(params, requestId, userId) as {
+				success: boolean;
+				id: string;
+				message: string;
+			};
+
+			expect(result.success).toBe(true);
+			expect(result.id).toBeDefined();
+			expect(typeof result.id).toBe("string");
+
+			// Verify in database
+			const row = db.queryOne<{
+				title: string;
+				context: string;
+				decision: string;
+				scope: string;
+				rationale: string;
+				alternatives: string;
+				related_files: string;
+			}>("SELECT * FROM decisions WHERE id = ?", [result.id]);
+
+			expect(row).toBeDefined();
+			expect(row?.title).toBe(params.title);
+			expect(row?.context).toBe(params.context);
+			expect(row?.decision).toBe(params.decision);
+			expect(row?.scope).toBe(params.scope);
+			expect(row?.rationale).toBe(params.rationale);
+			expect(JSON.parse(row?.alternatives || "[]")).toEqual(params.alternatives);
+			expect(JSON.parse(row?.related_files || "[]")).toEqual(params.related_files);
+		});
+
+		test("should record decision with minimal required fields", async () => {
+			const params = {
+				title: "Minimal decision",
+				context: "Context info",
+				decision: "Decision made",
+			};
+
+			const result = await executeRecordDecision(params, requestId, userId) as {
+				success: boolean;
+				id: string;
+			};
+
+			expect(result.success).toBe(true);
+			expect(result.id).toBeDefined();
+
+			// Verify defaults
+			const row = db.queryOne<{ scope: string; alternatives: string; related_files: string }>(
+				"SELECT scope, alternatives, related_files FROM decisions WHERE id = ?",
+				[result.id],
+			);
+
+			expect(row?.scope).toBe("pattern"); // Default scope
+			expect(JSON.parse(row?.alternatives || "[]")).toEqual([]);
+			expect(JSON.parse(row?.related_files || "[]")).toEqual([]);
+		});
+
+		test("should throw error when title is missing", async () => {
+			await expect(async () => {
+				await executeRecordDecision(
+					{ context: "test", decision: "test" },
+					requestId,
+					userId,
+				);
+			}).toThrow("Missing or invalid required parameter: title");
+		});
+
+		test("should throw error when context is missing", async () => {
+			await expect(async () => {
+				await executeRecordDecision(
+					{ title: "test", decision: "test" },
+					requestId,
+					userId,
+				);
+			}).toThrow("Missing or invalid required parameter: context");
+		});
+
+		test("should throw error when decision is missing", async () => {
+			await expect(async () => {
+				await executeRecordDecision(
+					{ title: "test", context: "test" },
+					requestId,
+					userId,
+				);
+			}).toThrow("Missing or invalid required parameter: decision");
+		});
+
+		test("should throw error for invalid scope", async () => {
+			await expect(async () => {
+				await executeRecordDecision(
+					{
+						title: "test",
+						context: "test",
+						decision: "test",
+						scope: "invalid-scope",
+					},
+					requestId,
+					userId,
+				);
+			}).toThrow("Parameter 'scope' must be one of");
+		});
+	});
+
+	describe("search_decisions", () => {
+		beforeEach(async () => {
+			// Insert test decisions
+			await executeRecordDecision(
+				{
+					title: "Use TypeScript for type safety",
+					context: "Need static typing",
+					decision: "Use TypeScript across the codebase",
+					scope: "architecture",
+					repository: testRepoId,
+				},
+				requestId,
+				userId,
+			);
+
+			await executeRecordDecision(
+				{
+					title: "Antimocking test pattern",
+					context: "Need reliable tests",
+					decision: "Use real SQLite in tests, no mocking",
+					scope: "pattern",
+					repository: testRepoId,
+				},
+				requestId,
+				userId,
+			);
+
+			await executeRecordDecision(
+				{
+					title: "Error logging conventions",
+					context: "Need consistent error handling",
+					decision: "Always use structured logging",
+					scope: "convention",
+					repository: testRepoId,
+				},
+				requestId,
+				userId,
+			);
+		});
+
+		test("should search decisions by query", async () => {
+			const result = await executeSearchDecisions(
+				{ query: "TypeScript" },
+				requestId,
+				userId,
+			) as {
+				results: Array<{ title: string; relevance: number }>;
+				count: number;
+			};
+
+			expect(result.results).toBeDefined();
+			expect(result.count).toBeGreaterThan(0);
+			expect(result.results[0]?.title).toContain("TypeScript");
+		});
+
+		test("should filter by scope", async () => {
+			const result = await executeSearchDecisions(
+				{ query: "test", scope: "pattern" },
+				requestId,
+				userId,
+			) as {
+				results: Array<{ scope: string }>;
+				count: number;
+			};
+
+			expect(result.count).toBeGreaterThan(0);
+			for (const decision of result.results) {
+				expect(decision.scope).toBe("pattern");
+			}
+		});
+
+		test("should return empty results for non-matching query", async () => {
+			const result = await executeSearchDecisions(
+				{ query: "nonexistent-term-xyz" },
+				requestId,
+				userId,
+			) as {
+				results: Array<unknown>;
+				count: number;
+			};
+
+			expect(result.results).toEqual([]);
+			expect(result.count).toBe(0);
+		});
+
+		test("should respect limit parameter", async () => {
+			const result = await executeSearchDecisions(
+				{ query: "decision", limit: 1 },
+				requestId,
+				userId,
+			) as {
+				results: Array<unknown>;
+				count: number;
+			};
+
+			expect(result.results.length).toBeLessThanOrEqual(1);
+		});
+
+		test("should return ranked results with relevance scores", async () => {
+			const result = await executeSearchDecisions(
+				{ query: "TypeScript" },
+				requestId,
+				userId,
+			) as {
+				results: Array<{ relevance: number }>;
+			};
+
+			expect(result.results.length).toBeGreaterThan(0);
+			expect(result.results[0]?.relevance).toBeDefined();
+			expect(typeof result.results[0]?.relevance).toBe("number");
+		});
+
+		test("should throw error when query is missing", async () => {
+			await expect(async () => {
+				await executeSearchDecisions({}, requestId, userId);
+			}).toThrow("Missing required parameter: query");
+		});
+	});
+
+	// ============================================================================
+	// Failure Recording & Search
+	// ============================================================================
+
+	describe("record_failure", () => {
+		test("should record a failed approach", async () => {
+			const params = {
+				title: "Tried using jest.mock",
+				problem: "Need to test database queries",
+				approach: "Used jest.mock to mock database calls",
+				failure_reason: "Mocks hide real integration bugs and add maintenance burden",
+				related_files: ["tests/db/queries.test.ts"],
+				repository: testRepoId,
+			};
+
+			const result = await executeRecordFailure(params, requestId, userId) as {
+				success: boolean;
+				id: string;
+			};
+
+			expect(result.success).toBe(true);
+			expect(result.id).toBeDefined();
+
+			// Verify in database
+			const row = db.queryOne<{
+				title: string;
+				problem: string;
+				approach: string;
+				failure_reason: string;
+				related_files: string;
+			}>("SELECT * FROM failures WHERE id = ?", [result.id]);
+
+			expect(row).toBeDefined();
+			expect(row?.title).toBe(params.title);
+			expect(row?.problem).toBe(params.problem);
+			expect(row?.approach).toBe(params.approach);
+			expect(row?.failure_reason).toBe(params.failure_reason);
+			expect(JSON.parse(row?.related_files || "[]")).toEqual(params.related_files);
+		});
+
+		test("should store related_files as JSON", async () => {
+			const params = {
+				title: "Failed approach",
+				problem: "Problem description",
+				approach: "Approach tried",
+				failure_reason: "Why it failed",
+				related_files: ["file1.ts", "file2.ts", "file3.ts"],
+			};
+
+			const result = await executeRecordFailure(params, requestId, userId) as {
+				success: boolean;
+				id: string;
+			};
+
+			const row = db.queryOne<{ related_files: string }>(
+				"SELECT related_files FROM failures WHERE id = ?",
+				[result.id],
+			);
+
+			const files = JSON.parse(row?.related_files || "[]");
+			expect(files).toEqual(params.related_files);
+			expect(files.length).toBe(3);
+		});
+
+		test("should throw error when title is missing", async () => {
+			await expect(async () => {
+				await executeRecordFailure(
+					{
+						problem: "test",
+						approach: "test",
+						failure_reason: "test",
+					},
+					requestId,
+					userId,
+				);
+			}).toThrow("Missing or invalid required parameter: title");
+		});
+
+		test("should throw error when problem is missing", async () => {
+			await expect(async () => {
+				await executeRecordFailure(
+					{
+						title: "test",
+						approach: "test",
+						failure_reason: "test",
+					},
+					requestId,
+					userId,
+				);
+			}).toThrow("Missing or invalid required parameter: problem");
+		});
+	});
+
+	describe("search_failures", () => {
+		beforeEach(async () => {
+			// Insert test failures
+			await executeRecordFailure(
+				{
+					title: "Jest mocking approach failed",
+					problem: "Testing database code",
+					approach: "Used jest.mock for database",
+					failure_reason: "Hidden integration bugs",
+					repository: testRepoId,
+				},
+				requestId,
+				userId,
+			);
+
+			await executeRecordFailure(
+				{
+					title: "Regex-only parsing failed",
+					problem: "Parse TypeScript imports",
+					approach: "Used regex to parse import statements",
+					failure_reason: "Cannot handle complex syntax",
+					repository: testRepoId,
+				},
+				requestId,
+				userId,
+			);
+		});
+
+		test("should search failures by query", async () => {
+			const result = await executeSearchFailures(
+				{ query: "jest" },
+				requestId,
+				userId,
+			) as {
+				results: Array<{ title: string }>;
+				count: number;
+			};
+
+			expect(result.results.length).toBeGreaterThan(0);
+			expect(result.results[0]?.title.toLowerCase()).toContain("jest");
+		});
+
+		test("should return FTS5 ranking", async () => {
+			const result = await executeSearchFailures(
+				{ query: "parsing" },
+				requestId,
+				userId,
+			) as {
+				results: Array<{ relevance: number }>;
+			};
+
+			expect(result.results.length).toBeGreaterThan(0);
+			expect(result.results[0]?.relevance).toBeDefined();
+			expect(typeof result.results[0]?.relevance).toBe("number");
+		});
+
+		test("should return empty results for non-matching query", async () => {
+			const result = await executeSearchFailures(
+				{ query: "nonexistent-xyz-term" },
+				requestId,
+				userId,
+			) as {
+				results: Array<unknown>;
+				count: number;
+			};
+
+			expect(result.results).toEqual([]);
+			expect(result.count).toBe(0);
+		});
+
+		test("should respect limit parameter", async () => {
+			const result = await executeSearchFailures(
+				{ query: "failed", limit: 1 },
+				requestId,
+				userId,
+			) as {
+				results: Array<unknown>;
+			};
+
+			expect(result.results.length).toBeLessThanOrEqual(1);
+		});
+
+		test("should throw error when query is missing", async () => {
+			await expect(async () => {
+				await executeSearchFailures({}, requestId, userId);
+			}).toThrow("Missing required parameter: query");
+		});
+	});
+
+	// ============================================================================
+	// Pattern Search
+	// ============================================================================
+
+	describe("search_patterns", () => {
+		beforeEach(() => {
+			// Insert test patterns directly
+			db.run(
+				`INSERT INTO patterns (id, repository_id, pattern_type, file_path, description, example, created_at)
+				VALUES (?, ?, ?, ?, ?, ?, datetime('now'))`,
+				[
+					randomUUID(),
+					testRepoId,
+					"error-handling",
+					"src/api/handler.ts",
+					"Try-catch with structured logging",
+					"try { ... } catch (err) { logger.error(...) }",
+				],
+			);
+
+			db.run(
+				`INSERT INTO patterns (id, repository_id, pattern_type, file_path, description, example, created_at)
+				VALUES (?, ?, ?, ?, ?, ?, datetime('now'))`,
+				[
+					randomUUID(),
+					testRepoId,
+					"error-handling",
+					"src/db/queries.ts",
+					"Database error handling",
+					"catch (err) { throw new DatabaseError() }",
+				],
+			);
+
+			db.run(
+				`INSERT INTO patterns (id, repository_id, pattern_type, file_path, description, example, created_at)
+				VALUES (?, ?, ?, ?, ?, ?, datetime('now'))`,
+				[
+					randomUUID(),
+					testRepoId,
+					"api-call",
+					"src/api/client.ts",
+					"REST API call pattern",
+					"await fetch(url).then(r => r.json())",
+				],
+			);
+		});
+
+		test("should search patterns by pattern_type", async () => {
+			const result = await executeSearchPatterns(
+				{ pattern_type: "error-handling" },
+				requestId,
+				userId,
+			) as {
+				results: Array<{ pattern_type: string }>;
+				count: number;
+			};
+
+			expect(result.count).toBe(2);
+			for (const pattern of result.results) {
+				expect(pattern.pattern_type).toBe("error-handling");
+			}
+		});
+
+		test("should filter by file", async () => {
+			const result = await executeSearchPatterns(
+				{ file: "src/api/handler.ts" },
+				requestId,
+				userId,
+			) as {
+				results: Array<{ file_path: string }>;
+				count: number;
+			};
+
+			expect(result.count).toBe(1);
+			expect(result.results[0]?.file_path).toBe("src/api/handler.ts");
+		});
+
+		test("should return empty array when no matches", async () => {
+			const result = await executeSearchPatterns(
+				{ pattern_type: "nonexistent-pattern" },
+				requestId,
+				userId,
+			) as {
+				results: Array<unknown>;
+				count: number;
+			};
+
+			expect(result.results).toEqual([]);
+			expect(result.count).toBe(0);
+		});
+
+		test("should respect limit parameter", async () => {
+			const result = await executeSearchPatterns(
+				{ pattern_type: "error-handling", limit: 1 },
+				requestId,
+				userId,
+			) as {
+				results: Array<unknown>;
+			};
+
+			expect(result.results.length).toBe(1);
+		});
+
+		test("should work with no parameters", async () => {
+			const result = await executeSearchPatterns(
+				{},
+				requestId,
+				userId,
+			) as {
+				results: Array<unknown>;
+				count: number;
+			};
+
+			expect(result.count).toBe(3);
+			expect(result.results.length).toBe(3);
+		});
+	});
+
+	// ============================================================================
+	// Session Insights
+	// ============================================================================
+
+	describe("record_insight", () => {
+		test("should record an insight", async () => {
+			const params = {
+				content: "Found that antimocking improves test reliability",
+				insight_type: "discovery",
+				session_id: randomUUID(),
+				related_file: "tests/db/queries.test.ts",
+			};
+
+			const result = await executeRecordInsight(params, requestId, userId) as {
+				success: boolean;
+				id: string;
+			};
+
+			expect(result.success).toBe(true);
+			expect(result.id).toBeDefined();
+
+			// Verify in database
+			const row = db.queryOne<{
+				content: string;
+				insight_type: string;
+				session_id: string;
+				related_file: string;
+			}>("SELECT * FROM insights WHERE id = ?", [result.id]);
+
+			expect(row).toBeDefined();
+			expect(row?.content).toBe(params.content);
+			expect(row?.insight_type).toBe(params.insight_type);
+			expect(row?.session_id).toBe(params.session_id);
+			expect(row?.related_file).toBe(params.related_file);
+		});
+
+		test("should record insight without session_id", async () => {
+			const params = {
+				content: "Workaround for circular dependency",
+				insight_type: "workaround",
+			};
+
+			const result = await executeRecordInsight(params, requestId, userId) as {
+				success: boolean;
+				id: string;
+			};
+
+			expect(result.success).toBe(true);
+
+			const row = db.queryOne<{ session_id: string | null }>(
+				"SELECT session_id FROM insights WHERE id = ?",
+				[result.id],
+			);
+
+			expect(row?.session_id).toBeNull();
+		});
+
+		test("should throw error when content is missing", async () => {
+			await expect(async () => {
+				await executeRecordInsight(
+					{ insight_type: "discovery" },
+					requestId,
+					userId,
+				);
+			}).toThrow("Missing or invalid required parameter: content");
+		});
+
+		test("should throw error when insight_type is missing", async () => {
+			await expect(async () => {
+				await executeRecordInsight(
+					{ content: "test content" },
+					requestId,
+					userId,
+				);
+			}).toThrow("Missing or invalid required parameter: insight_type");
+		});
+
+		test("should throw error for invalid insight_type", async () => {
+			await expect(async () => {
+				await executeRecordInsight(
+					{
+						content: "test",
+						insight_type: "invalid-type",
+					},
+					requestId,
+					userId,
+				);
+			}).toThrow("Parameter 'insight_type' must be one of");
+		});
+	});
+
+	// ============================================================================
+	// Integration Tests
+	// ============================================================================
+
+	describe("Integration: Full workflows", () => {
+		test("should record and search decision", async () => {
+			// Record decision
+			const recordResult = await executeRecordDecision(
+				{
+					title: "Path alias usage",
+					context: "Need consistent imports",
+					decision: "Always use @api, @db, @mcp aliases",
+					scope: "convention",
+					repository: testRepoId,
+				},
+				requestId,
+				userId,
+			) as { id: string };
+
+			// Search for it
+			const searchResult = await executeSearchDecisions(
+				{ query: "path alias" },
+				requestId,
+				userId,
+			) as {
+				results: Array<{ id: string; title: string }>;
+			};
+
+			expect(searchResult.results.length).toBeGreaterThan(0);
+			const found = searchResult.results.find((d) => d.id === recordResult.id);
+			expect(found).toBeDefined();
+			expect(found?.title).toBe("Path alias usage");
+		});
+
+		test("should record and search failure", async () => {
+			// Record failure
+			const recordResult = await executeRecordFailure(
+				{
+					title: "Global state in tests",
+					problem: "Tests were flaky",
+					approach: "Used shared database connection",
+					failure_reason: "Tests polluted each other's state",
+					repository: testRepoId,
+				},
+				requestId,
+				userId,
+			) as { id: string };
+
+			// Search for it
+			const searchResult = await executeSearchFailures(
+				{ query: "global state" },
+				requestId,
+				userId,
+			) as {
+				results: Array<{ id: string; title: string }>;
+			};
+
+			expect(searchResult.results.length).toBeGreaterThan(0);
+			const found = searchResult.results.find((f) => f.id === recordResult.id);
+			expect(found).toBeDefined();
+			expect(found?.title).toBe("Global state in tests");
+		});
+
+		test("should handle invalid repository gracefully", async () => {
+			// Non-existent repository should not throw, just use null
+			const result = await executeRecordDecision(
+				{
+					title: "Test decision",
+					context: "Test context",
+					decision: "Test decision",
+					repository: "nonexistent/repo",
+				},
+				requestId,
+				userId,
+			) as { success: boolean; id: string };
+
+			expect(result.success).toBe(true);
+
+			// Verify it was recorded with null repository_id
+			const row = db.queryOne<{ repository_id: string | null }>(
+				"SELECT repository_id FROM decisions WHERE id = ?",
+				[result.id],
+			);
+
+			expect(row?.repository_id).toBeNull();
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Implements Phase 2: Persistent Memory Layer (#99) - database tables and MCP tools for cross-session agent learning.

**What's added:**
- 5 database tables: `decisions`, `failures`, `pattern_annotations`, `agent_sessions`, `session_insights`
- 2 FTS5 virtual tables with automatic sync triggers for full-text search
- 6 new MCP tools for recording and searching memory data

## New MCP Tools

| Tool | Purpose |
|------|---------|
| `search_decisions` | Find past architectural decisions via FTS5 |
| `record_decision` | Store new architectural decision |
| `search_failures` | Find failed approaches to avoid repeating |
| `record_failure` | Store failed approach for future reference |
| `search_patterns` | Find codebase patterns by type |
| `record_insight` | Store session insight for future agents |

## Test plan

- [x] All 759 existing tests pass
- [x] 34 new memory layer tests added
- [x] TypeScript type check passes
- [x] Biome lint passes
- [x] Pre-commit hooks pass

## Files Changed

- `app/src/db/migrations/004_memory_layer.sql` - New migration with all tables
- `app/src/db/sqlite-schema.sql` - Schema additions
- `app/src/mcp/tools.ts` - 6 new tool implementations
- `app/src/mcp/server.ts` - Tool registration
- `app/tests/mcp/memory-tools.test.ts` - Comprehensive tests

Closes #99

🤖 Generated with [Claude Code](https://claude.ai/code)