### PR TITLE
feat(memory): integrate memory layer tools into agent workflow (#120)

### DIFF
--- a/.claude/agents/common/memory-usage.md
+++ b/.claude/agents/common/memory-usage.md
@@ -1,0 +1,145 @@
+# Memory Layer Usage Guide
+
+This guide covers how agents use the memory layer tools for cross-session learning.
+
+## Overview
+
+The memory layer provides persistent storage for:
+- **Decisions**: Architectural choices with rationale
+- **Failures**: Approaches that didn't work and why
+- **Patterns**: Discovered code patterns for consistency
+- **Insights**: Workarounds and discoveries
+
+## Tools Reference
+
+### Search Tools (Read-Only)
+
+#### search_decisions
+Find past architectural decisions.
+```
+search_decisions(
+  query: "search terms",
+  scope?: "architecture|pattern|convention|workaround",
+  limit?: 20
+)
+```
+
+#### search_failures
+Find past failed approaches.
+```
+search_failures(
+  query: "search terms",
+  limit?: 20
+)
+```
+
+#### search_patterns
+Find discovered code patterns.
+```
+search_patterns(
+  query?: "search terms",
+  pattern_type?: "error-handling|api-call|...",
+  limit?: 20
+)
+```
+
+### Recording Tools (Write)
+
+#### record_decision
+Record an architectural decision.
+```
+record_decision(
+  title: "Decision title",
+  context: "Background and problem",
+  decision: "What was decided",
+  rationale?: "Why this approach",
+  scope?: "architecture|pattern|convention|workaround",
+  alternatives?: ["other options considered"],
+  related_files?: ["file paths"]
+)
+```
+
+#### record_failure
+Record a failed approach.
+```
+record_failure(
+  title: "Failure title",
+  problem: "What was being solved",
+  approach: "What was tried",
+  failure_reason: "Why it failed",
+  related_files?: ["file paths"]
+)
+```
+
+#### record_insight
+Record a discovery or workaround.
+```
+record_insight(
+  content: "The insight",
+  insight_type: "discovery|failure|workaround",
+  related_file?: "file path"
+)
+```
+
+## Usage Patterns
+
+### Before Implementation (Build Agents)
+
+1. Search for relevant failures to avoid:
+   ```
+   search_failures("feature you're implementing")
+   ```
+
+2. Search for relevant decisions to follow:
+   ```
+   search_decisions("architectural area")
+   ```
+
+3. Search for patterns to maintain consistency:
+   ```
+   search_patterns(pattern_type: "relevant-type")
+   ```
+
+### During Implementation
+
+- When making architectural choices → `record_decision`
+- When an approach fails → `record_failure`
+- When finding workarounds → `record_insight`
+
+### After Analysis (Improve Agents)
+
+1. Analyze git changes for patterns
+2. Record significant decisions found
+3. Record any failed approaches discovered
+4. Record insights and workarounds
+
+## Best Practices
+
+### What to Record
+
+**DO record:**
+- Decisions affecting multiple files
+- Decisions others might need to follow
+- Failed approaches others might try
+- Non-obvious workarounds
+- Performance insights
+
+**DON'T record:**
+- Trivial implementation details
+- Temporary debugging info
+- Personal preferences
+- Incomplete experiments
+
+### Search Effectively
+
+- Use specific keywords from the task
+- Search by file path components
+- Search by technology (e.g., "FTS5", "MCP")
+- Check multiple related terms
+
+### Recording Quality
+
+- Titles should be descriptive and searchable
+- Context should explain "why" not just "what"
+- Include file paths for traceability
+- Be concise but complete

--- a/.claude/agents/experts/agent-authoring/agent-authoring-build-agent.md
+++ b/.claude/agents/experts/agent-authoring/agent-authoring-build-agent.md
@@ -11,6 +11,12 @@ tools:
   - mcp__kotadb-bunx__search_code
   - mcp__kotadb-bunx__search_dependencies
   - mcp__kotadb-bunx__analyze_change_impact
+  - mcp__kotadb-bunx__search_decisions
+  - mcp__kotadb-bunx__search_failures
+  - mcp__kotadb-bunx__search_patterns
+  - mcp__kotadb-bunx__record_decision
+  - mcp__kotadb-bunx__record_failure
+  - mcp__kotadb-bunx__record_insight
 model: sonnet
 color: green
 expertDomain: agent-authoring
@@ -89,7 +95,34 @@ NOT comma-separated: `tools: Read, Glob, Grep, Write`
 2. Brief intro paragraph
 3. `## Input Format` or `## Variables` - Expected inputs
 4. `## Capabilities` - What agent can do
-5. `## Workflow` - Numbered steps
+5. `## Memory Integration
+
+Before implementing, search for relevant past context:
+
+1. **Check Past Failures**
+   ```
+   search_failures("relevant keywords from your task")
+   ```
+   Apply learnings to avoid repeating mistakes.
+
+2. **Check Past Decisions**
+   ```
+   search_decisions("relevant architectural keywords")
+   ```
+   Follow established patterns and rationale.
+
+3. **Check Discovered Patterns**
+   ```
+   search_patterns(pattern_type: "relevant-type")
+   ```
+   Use consistent patterns across implementations.
+
+**During Implementation:**
+- Record significant architectural decisions with `record_decision`
+- Record failed approaches immediately with `record_failure`
+- Record workarounds or discoveries with `record_insight`
+
+## Workflow` - Numbered steps
 6. `## KotaDB Conventions` - REQUIRED for build agents
 7. `## Output Format` - Success/failure templates
 8. `## Error Handling` - Recovery patterns

--- a/.claude/agents/experts/agent-authoring/agent-authoring-improve-agent.md
+++ b/.claude/agents/experts/agent-authoring/agent-authoring-improve-agent.md
@@ -11,6 +11,12 @@ tools:
   - Task
   - mcp__kotadb-bunx__search_code
   - mcp__kotadb-bunx__search_dependencies
+  - mcp__kotadb-bunx__search_decisions
+  - mcp__kotadb-bunx__search_failures
+  - mcp__kotadb-bunx__search_patterns
+  - mcp__kotadb-bunx__record_decision
+  - mcp__kotadb-bunx__record_failure
+  - mcp__kotadb-bunx__record_insight
 model: sonnet
 color: purple
 expertDomain: agent-authoring
@@ -164,6 +170,48 @@ When approaching limits:
    - High kotadb-specific ratio (>0.7)
 
    → Domain may be reaching stability.
+
+## Memory Recording
+
+After analyzing changes, record significant findings for cross-session learning:
+
+### Record Architectural Decisions
+When you identify important design choices in the changes:
+```
+record_decision(
+  title: "Decision title",
+  context: "Why this decision was needed",
+  decision: "What was decided",
+  rationale: "Why this approach was chosen",
+  scope: "architecture|pattern|convention|workaround"
+)
+```
+
+### Record Failed Approaches
+When you identify approaches that didn't work:
+```
+record_failure(
+  title: "Failure title",
+  problem: "What was being solved",
+  approach: "What was tried",
+  failure_reason: "Why it failed"
+)
+```
+
+### Record Insights and Discoveries
+When you find workarounds or unexpected learnings:
+```
+record_insight(
+  content: "The insight or discovery",
+  insight_type: "discovery|failure|workaround"
+)
+```
+
+**Recording Guidelines:**
+- Record decisions that affect multiple files or future work
+- Record failures that others might repeat
+- Record workarounds for non-obvious problems
+- Include file paths in related_files when relevant
 
 ## Report
 

--- a/.claude/agents/experts/api/api-build-agent.md
+++ b/.claude/agents/experts/api/api-build-agent.md
@@ -11,6 +11,12 @@ tools:
   - mcp__kotadb-bunx__search_code
   - mcp__kotadb-bunx__search_dependencies
   - mcp__kotadb-bunx__analyze_change_impact
+  - mcp__kotadb-bunx__search_decisions
+  - mcp__kotadb-bunx__search_failures
+  - mcp__kotadb-bunx__search_patterns
+  - mcp__kotadb-bunx__record_decision
+  - mcp__kotadb-bunx__record_failure
+  - mcp__kotadb-bunx__record_insight
 model: sonnet
 color: green
 ---
@@ -223,6 +229,33 @@ registry.registerPath({
     },
 });
 ```
+
+## Memory Integration
+
+Before implementing, search for relevant past context:
+
+1. **Check Past Failures**
+   ```
+   search_failures("relevant keywords from your task")
+   ```
+   Apply learnings to avoid repeating mistakes.
+
+2. **Check Past Decisions**
+   ```
+   search_decisions("relevant architectural keywords")
+   ```
+   Follow established patterns and rationale.
+
+3. **Check Discovered Patterns**
+   ```
+   search_patterns(pattern_type: "relevant-type")
+   ```
+   Use consistent patterns across implementations.
+
+**During Implementation:**
+- Record significant architectural decisions with `record_decision`
+- Record failed approaches immediately with `record_failure`
+- Record workarounds or discoveries with `record_insight`
 
 ## Workflow
 

--- a/.claude/agents/experts/api/api-improve-agent.md
+++ b/.claude/agents/experts/api/api-improve-agent.md
@@ -11,6 +11,12 @@ tools:
   - Task
   - mcp__kotadb-bunx__search_code
   - mcp__kotadb-bunx__search_dependencies
+  - mcp__kotadb-bunx__search_decisions
+  - mcp__kotadb-bunx__search_failures
+  - mcp__kotadb-bunx__search_patterns
+  - mcp__kotadb-bunx__record_decision
+  - mcp__kotadb-bunx__record_failure
+  - mcp__kotadb-bunx__record_insight
 model: sonnet
 color: purple
 ---
@@ -196,6 +202,48 @@ Use Task to spawn sub-agents for complex analysis when needed.
    - Record API patterns that caused issues
    - Note structural decisions that were later refactored
    - Add to guidance for avoiding similar problems
+
+## Memory Recording
+
+After analyzing changes, record significant findings for cross-session learning:
+
+### Record Architectural Decisions
+When you identify important design choices in the changes:
+```
+record_decision(
+  title: "Decision title",
+  context: "Why this decision was needed",
+  decision: "What was decided",
+  rationale: "Why this approach was chosen",
+  scope: "architecture|pattern|convention|workaround"
+)
+```
+
+### Record Failed Approaches
+When you identify approaches that didn't work:
+```
+record_failure(
+  title: "Failure title",
+  problem: "What was being solved",
+  approach: "What was tried",
+  failure_reason: "Why it failed"
+)
+```
+
+### Record Insights and Discoveries
+When you find workarounds or unexpected learnings:
+```
+record_insight(
+  content: "The insight or discovery",
+  insight_type: "discovery|failure|workaround"
+)
+```
+
+**Recording Guidelines:**
+- Record decisions that affect multiple files or future work
+- Record failures that others might repeat
+- Record workarounds for non-obvious problems
+- Include file paths in related_files when relevant
 
 ## One-Time Cleanup Protocol
 

--- a/.claude/agents/experts/automation/automation-build-agent.md
+++ b/.claude/agents/experts/automation/automation-build-agent.md
@@ -11,6 +11,12 @@ tools:
   - mcp__kotadb-bunx__search_code
   - mcp__kotadb-bunx__search_dependencies
   - mcp__kotadb-bunx__analyze_change_impact
+  - mcp__kotadb-bunx__search_decisions
+  - mcp__kotadb-bunx__search_failures
+  - mcp__kotadb-bunx__search_patterns
+  - mcp__kotadb-bunx__record_decision
+  - mcp__kotadb-bunx__record_failure
+  - mcp__kotadb-bunx__record_insight
 model: sonnet
 color: green
 expertDomain: automation
@@ -163,6 +169,33 @@ if (exitCode !== 0) {
 **Markdown Table Format:**
 ```typescript
 const body = `
+## Memory Integration
+
+Before implementing, search for relevant past context:
+
+1. **Check Past Failures**
+   ```
+   search_failures("relevant keywords from your task")
+   ```
+   Apply learnings to avoid repeating mistakes.
+
+2. **Check Past Decisions**
+   ```
+   search_decisions("relevant architectural keywords")
+   ```
+   Follow established patterns and rationale.
+
+3. **Check Discovered Patterns**
+   ```
+   search_patterns(pattern_type: "relevant-type")
+   ```
+   Use consistent patterns across implementations.
+
+**During Implementation:**
+- Record significant architectural decisions with `record_decision`
+- Record failed approaches immediately with `record_failure`
+- Record workarounds or discoveries with `record_insight`
+
 ## Workflow Results
 
 | Metric | Value |

--- a/.claude/agents/experts/automation/automation-improve-agent.md
+++ b/.claude/agents/experts/automation/automation-improve-agent.md
@@ -11,6 +11,12 @@ tools:
   - Grep
   - mcp__kotadb-bunx__search_code
   - mcp__kotadb-bunx__search_dependencies
+  - mcp__kotadb-bunx__search_decisions
+  - mcp__kotadb-bunx__search_failures
+  - mcp__kotadb-bunx__search_patterns
+  - mcp__kotadb-bunx__record_decision
+  - mcp__kotadb-bunx__record_failure
+  - mcp__kotadb-bunx__record_insight
 model: sonnet
 color: purple
 expertDomain: automation
@@ -186,6 +192,48 @@ stability:
    - Note sections updated
    - Highlight significant patterns
    - Report expertise.yaml status
+
+## Memory Recording
+
+After analyzing changes, record significant findings for cross-session learning:
+
+### Record Architectural Decisions
+When you identify important design choices in the changes:
+```
+record_decision(
+  title: "Decision title",
+  context: "Why this decision was needed",
+  decision: "What was decided",
+  rationale: "Why this approach was chosen",
+  scope: "architecture|pattern|convention|workaround"
+)
+```
+
+### Record Failed Approaches
+When you identify approaches that didn't work:
+```
+record_failure(
+  title: "Failure title",
+  problem: "What was being solved",
+  approach: "What was tried",
+  failure_reason: "Why it failed"
+)
+```
+
+### Record Insights and Discoveries
+When you find workarounds or unexpected learnings:
+```
+record_insight(
+  content: "The insight or discovery",
+  insight_type: "discovery|failure|workaround"
+)
+```
+
+**Recording Guidelines:**
+- Record decisions that affect multiple files or future work
+- Record failures that others might repeat
+- Record workarounds for non-obvious problems
+- Include file paths in related_files when relevant
 
 ## Report
 

--- a/.claude/agents/experts/claude-config/claude-config-build-agent.md
+++ b/.claude/agents/experts/claude-config/claude-config-build-agent.md
@@ -11,6 +11,12 @@ tools:
   - mcp__kotadb-bunx__search_code
   - mcp__kotadb-bunx__search_dependencies
   - mcp__kotadb-bunx__analyze_change_impact
+  - mcp__kotadb-bunx__search_decisions
+  - mcp__kotadb-bunx__search_failures
+  - mcp__kotadb-bunx__search_patterns
+  - mcp__kotadb-bunx__record_decision
+  - mcp__kotadb-bunx__record_failure
+  - mcp__kotadb-bunx__record_insight
 model: sonnet
 color: green
 ---
@@ -241,6 +247,33 @@ Agents are documented in README.md tables:
 |-------|---------|-------------|-------|
 | agent-name | Brief purpose | Tool list | model |
 ```
+
+## Memory Integration
+
+Before implementing, search for relevant past context:
+
+1. **Check Past Failures**
+   ```
+   search_failures("relevant keywords from your task")
+   ```
+   Apply learnings to avoid repeating mistakes.
+
+2. **Check Past Decisions**
+   ```
+   search_decisions("relevant architectural keywords")
+   ```
+   Follow established patterns and rationale.
+
+3. **Check Discovered Patterns**
+   ```
+   search_patterns(pattern_type: "relevant-type")
+   ```
+   Use consistent patterns across implementations.
+
+**During Implementation:**
+- Record significant architectural decisions with `record_decision`
+- Record failed approaches immediately with `record_failure`
+- Record workarounds or discoveries with `record_insight`
 
 ## Workflow
 

--- a/.claude/agents/experts/claude-config/claude-config-improve-agent.md
+++ b/.claude/agents/experts/claude-config/claude-config-improve-agent.md
@@ -11,6 +11,12 @@ tools:
   - Task
   - mcp__kotadb-bunx__search_code
   - mcp__kotadb-bunx__search_dependencies
+  - mcp__kotadb-bunx__search_decisions
+  - mcp__kotadb-bunx__search_failures
+  - mcp__kotadb-bunx__search_patterns
+  - mcp__kotadb-bunx__record_decision
+  - mcp__kotadb-bunx__record_failure
+  - mcp__kotadb-bunx__record_insight
 model: sonnet
 color: purple
 ---
@@ -204,6 +210,48 @@ Use Task to spawn sub-agents for complex analysis when needed.
    - Record configuration patterns that caused issues
    - Note structural decisions that were later refactored
    - Add to guidance for avoiding similar problems
+
+## Memory Recording
+
+After analyzing changes, record significant findings for cross-session learning:
+
+### Record Architectural Decisions
+When you identify important design choices in the changes:
+```
+record_decision(
+  title: "Decision title",
+  context: "Why this decision was needed",
+  decision: "What was decided",
+  rationale: "Why this approach was chosen",
+  scope: "architecture|pattern|convention|workaround"
+)
+```
+
+### Record Failed Approaches
+When you identify approaches that didn't work:
+```
+record_failure(
+  title: "Failure title",
+  problem: "What was being solved",
+  approach: "What was tried",
+  failure_reason: "Why it failed"
+)
+```
+
+### Record Insights and Discoveries
+When you find workarounds or unexpected learnings:
+```
+record_insight(
+  content: "The insight or discovery",
+  insight_type: "discovery|failure|workaround"
+)
+```
+
+**Recording Guidelines:**
+- Record decisions that affect multiple files or future work
+- Record failures that others might repeat
+- Record workarounds for non-obvious problems
+- Include file paths in related_files when relevant
 
 ## One-Time Cleanup Protocol
 

--- a/.claude/agents/experts/database/database-build-agent.md
+++ b/.claude/agents/experts/database/database-build-agent.md
@@ -11,6 +11,12 @@ tools:
   - mcp__kotadb-bunx__search_code
   - mcp__kotadb-bunx__search_dependencies
   - mcp__kotadb-bunx__analyze_change_impact
+  - mcp__kotadb-bunx__search_decisions
+  - mcp__kotadb-bunx__search_failures
+  - mcp__kotadb-bunx__search_patterns
+  - mcp__kotadb-bunx__record_decision
+  - mcp__kotadb-bunx__record_failure
+  - mcp__kotadb-bunx__record_insight
 model: sonnet
 color: green
 ---
@@ -204,6 +210,33 @@ function queryDependencies(db: KotaDatabase, sourceId: string, maxDepth: number)
 - Verify indexes with PRAGMA index_list(table_name)
 - Test FTS5 with simple MATCH query
 - Use EXPLAIN QUERY PLAN to verify index usage
+
+## Memory Integration
+
+Before implementing, search for relevant past context:
+
+1. **Check Past Failures**
+   ```
+   search_failures("relevant keywords from your task")
+   ```
+   Apply learnings to avoid repeating mistakes.
+
+2. **Check Past Decisions**
+   ```
+   search_decisions("relevant architectural keywords")
+   ```
+   Follow established patterns and rationale.
+
+3. **Check Discovered Patterns**
+   ```
+   search_patterns(pattern_type: "relevant-type")
+   ```
+   Use consistent patterns across implementations.
+
+**During Implementation:**
+- Record significant architectural decisions with `record_decision`
+- Record failed approaches immediately with `record_failure`
+- Record workarounds or discoveries with `record_insight`
 
 ## Workflow
 

--- a/.claude/agents/experts/database/database-improve-agent.md
+++ b/.claude/agents/experts/database/database-improve-agent.md
@@ -11,6 +11,12 @@ tools:
   - Task
   - mcp__kotadb-bunx__search_code
   - mcp__kotadb-bunx__search_dependencies
+  - mcp__kotadb-bunx__search_decisions
+  - mcp__kotadb-bunx__search_failures
+  - mcp__kotadb-bunx__search_patterns
+  - mcp__kotadb-bunx__record_decision
+  - mcp__kotadb-bunx__record_failure
+  - mcp__kotadb-bunx__record_insight
 model: sonnet
 color: purple
 ---
@@ -199,6 +205,48 @@ Use Task to spawn sub-agents for complex analysis when needed.
    - Record database patterns that caused issues
    - Note schema decisions that were later refactored
    - Add to guidance for avoiding similar problems
+
+## Memory Recording
+
+After analyzing changes, record significant findings for cross-session learning:
+
+### Record Architectural Decisions
+When you identify important design choices in the changes:
+```
+record_decision(
+  title: "Decision title",
+  context: "Why this decision was needed",
+  decision: "What was decided",
+  rationale: "Why this approach was chosen",
+  scope: "architecture|pattern|convention|workaround"
+)
+```
+
+### Record Failed Approaches
+When you identify approaches that didn't work:
+```
+record_failure(
+  title: "Failure title",
+  problem: "What was being solved",
+  approach: "What was tried",
+  failure_reason: "Why it failed"
+)
+```
+
+### Record Insights and Discoveries
+When you find workarounds or unexpected learnings:
+```
+record_insight(
+  content: "The insight or discovery",
+  insight_type: "discovery|failure|workaround"
+)
+```
+
+**Recording Guidelines:**
+- Record decisions that affect multiple files or future work
+- Record failures that others might repeat
+- Record workarounds for non-obvious problems
+- Include file paths in related_files when relevant
 
 ## One-Time Cleanup Protocol
 

--- a/.claude/agents/experts/documentation/documentation-improve-agent.md
+++ b/.claude/agents/experts/documentation/documentation-improve-agent.md
@@ -11,6 +11,12 @@ tools:
   - Task
   - mcp__kotadb-bunx__search_code
   - mcp__kotadb-bunx__search_dependencies
+  - mcp__kotadb-bunx__search_decisions
+  - mcp__kotadb-bunx__search_failures
+  - mcp__kotadb-bunx__search_patterns
+  - mcp__kotadb-bunx__record_decision
+  - mcp__kotadb-bunx__record_failure
+  - mcp__kotadb-bunx__record_insight
 model: sonnet
 color: purple
 ---
@@ -188,6 +194,48 @@ Use Task to spawn sub-agents for complex analysis when needed.
    - Record documentation patterns that caused issues
    - Note structural decisions that were later refactored
    - Add to guidance for avoiding similar problems
+
+## Memory Recording
+
+After analyzing changes, record significant findings for cross-session learning:
+
+### Record Architectural Decisions
+When you identify important design choices in the changes:
+```
+record_decision(
+  title: "Decision title",
+  context: "Why this decision was needed",
+  decision: "What was decided",
+  rationale: "Why this approach was chosen",
+  scope: "architecture|pattern|convention|workaround"
+)
+```
+
+### Record Failed Approaches
+When you identify approaches that didn't work:
+```
+record_failure(
+  title: "Failure title",
+  problem: "What was being solved",
+  approach: "What was tried",
+  failure_reason: "Why it failed"
+)
+```
+
+### Record Insights and Discoveries
+When you find workarounds or unexpected learnings:
+```
+record_insight(
+  content: "The insight or discovery",
+  insight_type: "discovery|failure|workaround"
+)
+```
+
+**Recording Guidelines:**
+- Record decisions that affect multiple files or future work
+- Record failures that others might repeat
+- Record workarounds for non-obvious problems
+- Include file paths in related_files when relevant
 
 ## One-Time Cleanup Protocol
 

--- a/.claude/agents/experts/github/github-build-agent.md
+++ b/.claude/agents/experts/github/github-build-agent.md
@@ -11,6 +11,12 @@ tools:
   - mcp__kotadb-bunx__search_code
   - mcp__kotadb-bunx__search_dependencies
   - mcp__kotadb-bunx__analyze_change_impact
+  - mcp__kotadb-bunx__search_decisions
+  - mcp__kotadb-bunx__search_failures
+  - mcp__kotadb-bunx__search_patterns
+  - mcp__kotadb-bunx__record_decision
+  - mcp__kotadb-bunx__record_failure
+  - mcp__kotadb-bunx__record_insight
 model: sonnet
 color: green
 ---
@@ -207,6 +213,33 @@ gh release list --limit 10
 - GitHub Release: Created automatically with gh release create --verify-tag
 - Release notes: Include npm registry URL for discoverability
 - Workflow summary: Auto-generated publish status reported in job summary
+
+## Memory Integration
+
+Before implementing, search for relevant past context:
+
+1. **Check Past Failures**
+   ```
+   search_failures("relevant keywords from your task")
+   ```
+   Apply learnings to avoid repeating mistakes.
+
+2. **Check Past Decisions**
+   ```
+   search_decisions("relevant architectural keywords")
+   ```
+   Follow established patterns and rationale.
+
+3. **Check Discovered Patterns**
+   ```
+   search_patterns(pattern_type: "relevant-type")
+   ```
+   Use consistent patterns across implementations.
+
+**During Implementation:**
+- Record significant architectural decisions with `record_decision`
+- Record failed approaches immediately with `record_failure`
+- Record workarounds or discoveries with `record_insight`
 
 ## Workflow
 

--- a/.claude/agents/experts/github/github-improve-agent.md
+++ b/.claude/agents/experts/github/github-improve-agent.md
@@ -11,6 +11,12 @@ tools:
   - Task
   - mcp__kotadb-bunx__search_code
   - mcp__kotadb-bunx__search_dependencies
+  - mcp__kotadb-bunx__search_decisions
+  - mcp__kotadb-bunx__search_failures
+  - mcp__kotadb-bunx__search_patterns
+  - mcp__kotadb-bunx__record_decision
+  - mcp__kotadb-bunx__record_failure
+  - mcp__kotadb-bunx__record_insight
 model: sonnet
 color: purple
 ---
@@ -196,6 +202,48 @@ Use Task to spawn sub-agents for complex analysis when needed.
    - Record workflow patterns that caused issues
    - Note decisions that were later refactored
    - Add to guidance for avoiding similar problems
+
+## Memory Recording
+
+After analyzing changes, record significant findings for cross-session learning:
+
+### Record Architectural Decisions
+When you identify important design choices in the changes:
+```
+record_decision(
+  title: "Decision title",
+  context: "Why this decision was needed",
+  decision: "What was decided",
+  rationale: "Why this approach was chosen",
+  scope: "architecture|pattern|convention|workaround"
+)
+```
+
+### Record Failed Approaches
+When you identify approaches that didn't work:
+```
+record_failure(
+  title: "Failure title",
+  problem: "What was being solved",
+  approach: "What was tried",
+  failure_reason: "Why it failed"
+)
+```
+
+### Record Insights and Discoveries
+When you find workarounds or unexpected learnings:
+```
+record_insight(
+  content: "The insight or discovery",
+  insight_type: "discovery|failure|workaround"
+)
+```
+
+**Recording Guidelines:**
+- Record decisions that affect multiple files or future work
+- Record failures that others might repeat
+- Record workarounds for non-obvious problems
+- Include file paths in related_files when relevant
 
 ## One-Time Cleanup Protocol
 

--- a/.claude/agents/experts/indexer/indexer-build-agent.md
+++ b/.claude/agents/experts/indexer/indexer-build-agent.md
@@ -11,6 +11,12 @@ tools:
   - mcp__kotadb-bunx__search_code
   - mcp__kotadb-bunx__search_dependencies
   - mcp__kotadb-bunx__analyze_change_impact
+  - mcp__kotadb-bunx__search_decisions
+  - mcp__kotadb-bunx__search_failures
+  - mcp__kotadb-bunx__search_patterns
+  - mcp__kotadb-bunx__record_decision
+  - mcp__kotadb-bunx__record_failure
+  - mcp__kotadb-bunx__record_insight
 model: sonnet
 color: green
 ---
@@ -211,6 +217,33 @@ if (!fileId) {
 - Use real SQLite in-memory database (no mocks)
 - Test files in app/tests/indexer/
 - Naming: `<module>.test.ts`
+
+## Memory Integration
+
+Before implementing, search for relevant past context:
+
+1. **Check Past Failures**
+   ```
+   search_failures("relevant keywords from your task")
+   ```
+   Apply learnings to avoid repeating mistakes.
+
+2. **Check Past Decisions**
+   ```
+   search_decisions("relevant architectural keywords")
+   ```
+   Follow established patterns and rationale.
+
+3. **Check Discovered Patterns**
+   ```
+   search_patterns(pattern_type: "relevant-type")
+   ```
+   Use consistent patterns across implementations.
+
+**During Implementation:**
+- Record significant architectural decisions with `record_decision`
+- Record failed approaches immediately with `record_failure`
+- Record workarounds or discoveries with `record_insight`
 
 ## Workflow
 

--- a/.claude/agents/experts/indexer/indexer-improve-agent.md
+++ b/.claude/agents/experts/indexer/indexer-improve-agent.md
@@ -11,6 +11,12 @@ tools:
   - Task
   - mcp__kotadb-bunx__search_code
   - mcp__kotadb-bunx__search_dependencies
+  - mcp__kotadb-bunx__search_decisions
+  - mcp__kotadb-bunx__search_failures
+  - mcp__kotadb-bunx__search_patterns
+  - mcp__kotadb-bunx__record_decision
+  - mcp__kotadb-bunx__record_failure
+  - mcp__kotadb-bunx__record_insight
 model: sonnet
 color: purple
 ---
@@ -194,6 +200,48 @@ Use Task to spawn sub-agents for complex analysis when needed.
    - Record indexer patterns that caused issues
    - Note structural decisions that were later refactored
    - Add to guidance for avoiding similar problems
+
+## Memory Recording
+
+After analyzing changes, record significant findings for cross-session learning:
+
+### Record Architectural Decisions
+When you identify important design choices in the changes:
+```
+record_decision(
+  title: "Decision title",
+  context: "Why this decision was needed",
+  decision: "What was decided",
+  rationale: "Why this approach was chosen",
+  scope: "architecture|pattern|convention|workaround"
+)
+```
+
+### Record Failed Approaches
+When you identify approaches that didn't work:
+```
+record_failure(
+  title: "Failure title",
+  problem: "What was being solved",
+  approach: "What was tried",
+  failure_reason: "Why it failed"
+)
+```
+
+### Record Insights and Discoveries
+When you find workarounds or unexpected learnings:
+```
+record_insight(
+  content: "The insight or discovery",
+  insight_type: "discovery|failure|workaround"
+)
+```
+
+**Recording Guidelines:**
+- Record decisions that affect multiple files or future work
+- Record failures that others might repeat
+- Record workarounds for non-obvious problems
+- Include file paths in related_files when relevant
 
 ## One-Time Cleanup Protocol
 

--- a/.claude/agents/experts/testing/testing-build-agent.md
+++ b/.claude/agents/experts/testing/testing-build-agent.md
@@ -11,6 +11,12 @@ tools:
   - mcp__kotadb-bunx__search_code
   - mcp__kotadb-bunx__search_dependencies
   - mcp__kotadb-bunx__analyze_change_impact
+  - mcp__kotadb-bunx__search_decisions
+  - mcp__kotadb-bunx__search_failures
+  - mcp__kotadb-bunx__search_patterns
+  - mcp__kotadb-bunx__record_decision
+  - mcp__kotadb-bunx__record_failure
+  - mcp__kotadb-bunx__record_insight
 model: sonnet
 color: green
 ---
@@ -166,6 +172,33 @@ test.each(cases)("should transform $input to $expected", ({ input, expected }) =
   expect(transform(input)).toBe(expected);
 });
 ```
+
+## Memory Integration
+
+Before implementing, search for relevant past context:
+
+1. **Check Past Failures**
+   ```
+   search_failures("relevant keywords from your task")
+   ```
+   Apply learnings to avoid repeating mistakes.
+
+2. **Check Past Decisions**
+   ```
+   search_decisions("relevant architectural keywords")
+   ```
+   Follow established patterns and rationale.
+
+3. **Check Discovered Patterns**
+   ```
+   search_patterns(pattern_type: "relevant-type")
+   ```
+   Use consistent patterns across implementations.
+
+**During Implementation:**
+- Record significant architectural decisions with `record_decision`
+- Record failed approaches immediately with `record_failure`
+- Record workarounds or discoveries with `record_insight`
 
 ## Workflow
 

--- a/.claude/agents/experts/testing/testing-improve-agent.md
+++ b/.claude/agents/experts/testing/testing-improve-agent.md
@@ -11,6 +11,12 @@ tools:
   - Task
   - mcp__kotadb-bunx__search_code
   - mcp__kotadb-bunx__search_dependencies
+  - mcp__kotadb-bunx__search_decisions
+  - mcp__kotadb-bunx__search_failures
+  - mcp__kotadb-bunx__search_patterns
+  - mcp__kotadb-bunx__record_decision
+  - mcp__kotadb-bunx__record_failure
+  - mcp__kotadb-bunx__record_insight
 model: sonnet
 color: purple
 ---
@@ -196,6 +202,48 @@ Use Task to spawn sub-agents for complex analysis when needed.
    - Record testing patterns that caused issues
    - Note test designs that led to flaky tests
    - Add to guidance for avoiding similar problems
+
+## Memory Recording
+
+After analyzing changes, record significant findings for cross-session learning:
+
+### Record Architectural Decisions
+When you identify important design choices in the changes:
+```
+record_decision(
+  title: "Decision title",
+  context: "Why this decision was needed",
+  decision: "What was decided",
+  rationale: "Why this approach was chosen",
+  scope: "architecture|pattern|convention|workaround"
+)
+```
+
+### Record Failed Approaches
+When you identify approaches that didn't work:
+```
+record_failure(
+  title: "Failure title",
+  problem: "What was being solved",
+  approach: "What was tried",
+  failure_reason: "Why it failed"
+)
+```
+
+### Record Insights and Discoveries
+When you find workarounds or unexpected learnings:
+```
+record_insight(
+  content: "The insight or discovery",
+  insight_type: "discovery|failure|workaround"
+)
+```
+
+**Recording Guidelines:**
+- Record decisions that affect multiple files or future work
+- Record failures that others might repeat
+- Record workarounds for non-obvious problems
+- Include file paths in related_files when relevant
 
 ## One-Time Cleanup Protocol
 

--- a/.claude/hooks/kotadb/memory-recall.py
+++ b/.claude/hooks/kotadb/memory-recall.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""
+PreToolUse hook for injecting memory context before file edits.
+
+This hook is triggered when Claude Code uses Edit, Write, or MultiEdit tools.
+It queries KotaDB for relevant failures and decisions based on the file being
+edited, and injects context to help avoid past mistakes and follow established
+patterns.
+
+Hook Configuration (in .claude/settings.json):
+{
+  "hooks": {
+    "PreToolUse": [{
+      "matcher": "Edit|Write|MultiEdit",
+      "hooks": [{
+        "type": "command",
+        "command": "python3 .claude/hooks/kotadb/memory-recall.py"
+      }]
+    }]
+  }
+}
+
+Input (stdin JSON):
+{
+  "tool_name": "Edit",
+  "tool_input": {
+    "file_path": "/path/to/file.ts",
+    ...
+  }
+}
+
+Output (stdout):
+Memory context if relevant failures/decisions found, otherwise empty.
+
+Exit codes:
+- 0: Success (always - don't block tool execution)
+"""
+
+import os
+import sys
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from utils.hook_helpers import (
+    parse_stdin,
+    extract_file_path,
+    extract_search_terms_from_path,
+    run_kotadb_search_failures,
+    run_kotadb_search_decisions,
+    format_memory_context,
+    output_continue,
+    output_context,
+)
+
+
+def main() -> None:
+    """Main hook entry point."""
+    # Parse input from Claude Code
+    hook_input = parse_stdin()
+    
+    if not hook_input:
+        # No input, continue without context
+        output_continue()
+        return
+    
+    # Extract file path from tool input
+    file_path = extract_file_path(hook_input)
+    
+    if not file_path:
+        # No file path found, continue without context
+        output_continue()
+        return
+    
+    # Convert absolute path to relative for context extraction
+    cwd = os.getcwd()
+    relative_path = file_path
+    if file_path.startswith(cwd):
+        relative_path = file_path[len(cwd):].lstrip("/")
+    
+    # Extract search terms from the file path
+    search_terms = extract_search_terms_from_path(relative_path)
+    
+    if not search_terms:
+        # No meaningful terms extracted, continue without context
+        output_continue()
+        return
+    
+    # Build a search query from terms
+    search_query = " ".join(search_terms)
+    
+    # Search for relevant failures and decisions
+    failures_result = run_kotadb_search_failures(search_query, limit=5)
+    decisions_result = run_kotadb_search_decisions(search_query, limit=5)
+    
+    # Check for errors (log to stderr but don't block)
+    if failures_result.get("error"):
+        sys.stderr.write(f"[kotadb-memory] Warning: {failures_result['error']}\n")
+    if decisions_result.get("error"):
+        sys.stderr.write(f"[kotadb-memory] Warning: {decisions_result['error']}\n")
+    
+    # Extract results arrays
+    failures = failures_result.get("results", [])
+    decisions = decisions_result.get("results", [])
+    
+    # Format and output memory context if we have any results
+    context = format_memory_context(failures, decisions)
+    
+    if context:
+        output_context(context)
+    else:
+        output_continue()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Integrates the memory layer MCP tools from #119 into the agent workflow, enabling cross-session learning.

- **8 build agents** now have memory tools + pre-implementation search instructions
- **9 improve agents** now have memory tools + post-analysis recording instructions
- **New PreToolUse hook** auto-searches failures/decisions before Edit/Write operations
- **Shared documentation** for consistent memory tool usage across agents

## Changes

### Build Agents (8 files)
Added to each:
- 6 memory tools in frontmatter (`search_decisions`, `search_failures`, `search_patterns`, `record_decision`, `record_failure`, `record_insight`)
- New "Memory Integration" section with pre-implementation search instructions

### Improve Agents (9 files)
Added to each:
- 6 memory tools in frontmatter
- New "Memory Recording" section with templates for recording decisions, failures, and insights

### New Files
| File | Purpose |
|------|---------|
| `.claude/hooks/kotadb/memory-recall.py` | PreToolUse hook that auto-searches memory before Edit/Write/MultiEdit |
| `.claude/agents/common/memory-usage.md` | Shared documentation for memory tool usage |
| `.claude/hooks/utils/hook_helpers.py` | +5 new helper functions for memory operations |

## Test plan

- [ ] Verify build agents can call `search_failures` and `search_decisions`
- [ ] Verify improve agents can call `record_decision`, `record_failure`, `record_insight`
- [ ] Test memory-recall hook triggers on file edits
- [ ] Confirm hook outputs memory context when relevant records exist
- [ ] Verify hook doesn't block operations when MCP server unavailable

## Related

- Closes #120
- Depends on: #119 (memory layer storage)
- Part of: #97 (Epic: KotaDB as Invisible Intelligence Layer)

🤖 Generated with [Claude Code](https://claude.ai/code)