### PR TITLE
feat(expertise): add dynamic expertise tools (#100)

### DIFF
--- a/.claude/agents/experts/agent-authoring/expertise.yaml
+++ b/.claude/agents/experts/agent-authoring/expertise.yaml
@@ -166,9 +166,9 @@ key_operations:
       - Reserved for future complex orchestration needs
       - Only when complexity justifies cost
     examples:
-      - agent: scout-agent | model: haiku | reason: Fast read-only search
-      - agent: automation-question-agent | model: haiku | reason: Fast Q&A on SDK patterns
-      - agent: automation-build-agent | model: sonnet | reason: Complex SDK implementation
+      - "agent: scout-agent | model: haiku | reason: Fast read-only search"
+      - "agent: automation-question-agent | model: haiku | reason: Fast Q&A on SDK patterns"
+      - "agent: automation-build-agent | model: sonnet | reason: Complex SDK implementation"
 
   write_agent_description:
     name: Write Effective Agent Description
@@ -196,7 +196,7 @@ key_operations:
       - good: "Plans automation layer changes for kotadb. Expects USER_PROMPT (SDK or workflow requirement)"
       - good: "Automation expertise evolution specialist"
       - good: "Automation Q&A specialist. Answers questions about SDK patterns and workflow execution"
-      - bad: "Plans: implementation" (colon breaks parser)
+      - bad: "Plans: implementation (colon breaks parser)"
 
   structure_agent_prompt:
     name: Structure Agent System Prompt Content (kotadb)
@@ -649,6 +649,18 @@ recent_changes:
       5. Preserve worktrees on failure for debugging, on success for PR review
     timestamp: 2026-02-01
 
+  - category: Documentation Patterns (NEW LEARNING [2026-02-01])
+    practices:
+      - practice: Create supplemental learnings files for large feature implementations
+        evidence: automation/worktree-learnings.md (101 lines) documents worktree isolation separately from expertise.yaml
+        timestamp: 2026-02-01
+      - practice: Structure learnings files with Overview, Operations, Patterns, Practices, Pitfalls, Integration
+        evidence: worktree-learnings.md demonstrates comprehensive yet focused structure
+        timestamp: 2026-02-01
+      - practice: Reference learnings files from expertise.yaml for deep dives
+        evidence: Keeps expertise.yaml focused on high-level patterns while preserving implementation details
+        timestamp: 2026-02-01
+
 stability:
   convergence_indicators:
     insight_rate_trend: "stabilizing"
@@ -684,15 +696,4 @@ stability:
       - Tool selection guidance standardized across core and expert agents
       
       Domain showing maturation with meta-patterns for documentation and knowledge capture.
-  - category: Documentation Patterns (NEW LEARNING [2026-02-01])
-    practices:
-      - practice: Create supplemental learnings files for large feature implementations
-        evidence: automation/worktree-learnings.md (101 lines) documents worktree isolation separately from expertise.yaml
-        timestamp: 2026-02-01
-      - practice: Structure learnings files with Overview, Operations, Patterns, Practices, Pitfalls, Integration
-        evidence: worktree-learnings.md demonstrates comprehensive yet focused structure
-        timestamp: 2026-02-01
-      - practice: Reference learnings files from expertise.yaml for deep dives
-        evidence: Keeps expertise.yaml focused on high-level patterns while preserving implementation details
-        timestamp: 2026-02-01
 

--- a/.claude/agents/experts/api/expertise.yaml
+++ b/.claude/agents/experts/api/expertise.yaml
@@ -680,7 +680,7 @@ known_issues:
     resolution: Call clearSpecCache() during development
 
   - issue: FTS5 syntax errors from unescaped input
-    impact: "no such column" errors on hyphenated/multi-word searches
+    impact: '"no such column" errors on hyphenated/multi-word searches'
     status: resolved (2026-01-28, commit 5af086f)
     resolution: Always use escapeFts5Term() before MATCH
 

--- a/.claude/agents/experts/claude-config/expertise.yaml
+++ b/.claude/agents/experts/claude-config/expertise.yaml
@@ -588,11 +588,12 @@ best_practices:
 
   expert_expansion:
     timestamp: 2026-01-28
-    - Document all expert domains in CLAUDE.md for discoverability
-    - Use multi-line JSON arrays in agent-registry.json for git diffs
-    - Keep /do domain detection patterns specific and non-overlapping
-    - Update all 3 files (CLAUDE.md, do.md, agent-registry.json) atomically
-    - Grant consistent tool permissions across agent types within domain
+    insights:
+      - Document all expert domains in CLAUDE.md for discoverability
+      - Use multi-line JSON arrays in agent-registry.json for git diffs
+      - Keep /do domain detection patterns specific and non-overlapping
+      - Update all 3 files (CLAUDE.md, do.md, agent-registry.json) atomically
+      - Grant consistent tool permissions across agent types within domain
 
 known_issues:
   - issue: Colons in frontmatter description values break YAML parsing

--- a/.claude/agents/experts/documentation/expertise.yaml
+++ b/.claude/agents/experts/documentation/expertise.yaml
@@ -258,7 +258,7 @@ key_operations:
       kotadb index --local-path /path/to/your/repo
       ```
     pitfalls:
-      - Incorrect CLI parameter format (old: kotadb index /path vs new: --local-path)
+      - "Incorrect CLI parameter format (old: kotadb index /path vs new: --local-path)"
       - Wrong default ports (3000 vs 8080)
       - Missing environment variable configuration
       - Untested troubleshooting advice
@@ -466,17 +466,19 @@ best_practices:
     - Maintain navigation order for user experience
 
   slash_command_documentation:
-    - Validate all documented commands exist as files
-    - Keep directory structure lists current
-    - Remove commands promptly when files are deleted
-    - Use /subdirectory:filename format consistently
+    items:
+      - Validate all documented commands exist as files
+      - Keep directory structure lists current
+      - Remove commands promptly when files are deleted
+      - "Use /subdirectory:filename format consistently"
     timestamp: 2026-02-02
 
   cross_file_consistency:
-    - Define canonical source for shared information
-    - Update all related files when canonical changes
-    - Expert domain counts must match across CLAUDE.md and README.md
-    - Technology stack claims must be consistent
+    items:
+      - Define canonical source for shared information
+      - Update all related files when canonical changes
+      - Expert domain counts must match across CLAUDE.md and README.md
+      - Technology stack claims must be consistent
     timestamp: 2026-02-02
 
 known_issues:

--- a/.claude/agents/experts/github/expertise.yaml
+++ b/.claude/agents/experts/github/expertise.yaml
@@ -129,7 +129,7 @@ core_implementation:
       - anti_mock_statement: Confirmation no new mocks introduced
       - plan_link: Link to spec file if exists
       - closes: "Closes #<issue_number>"
-      - adw_id: "ADW ID: <id>" if applicable
+      - adw_id: "ADW ID: <id> if applicable"
 
   key_files:
     - path: .claude/commands/issues/feature.md

--- a/.claude/agents/experts/indexer/expertise.yaml
+++ b/.claude/agents/experts/indexer/expertise.yaml
@@ -166,26 +166,13 @@ key_operations:
       ```
       
       Recovery capabilities:
+      Recovery capabilities:
       - Minor syntax errors (missing semicolons handled by ASI)
       - Unclosed braces (may recover valid nodes before error)
       - Multiple syntax errors (attempts to extract valid sections)
       - Complete failures (regex fallback for basic pattern matching)
       
-      Regex fallback error_recovery_strategy:
-    question: How should I handle parse errors for this file?
-    options:
-      - if: parseFileWithRecovery returns ast with partial:false
-        then: Use AST normally (no errors)
-      - if: parseFileWithRecovery returns ast with partial:true
-        then: Use partial AST, log warning, extract available symbols
-      - if: parseFileWithRecovery returns null with errors
-        then: Use regex fallback (extractSymbolsWithRegex)
-      - if: Regex fallback returns empty array
-        then: Log error, skip file (no symbols available)
-      - if: Symbol has metadata.extractionMethod: "regex"
-        then: Use with caution (may lack JSDoc, accurate positions)
-
-patterns:
+      Regex fallback patterns:
       - Functions: /export\s+(?:async\s+)?function\s+(\w+)/
       - Classes: /export\s+(?:abstract\s+)?class\s+(\w+)/
       - Interfaces: /export\s+interface\s+(\w+)/
@@ -216,7 +203,7 @@ patterns:
         instead: Log warnings for partial recovery, errors for complete failures
         reason: Observability helps identify problematic files
     timestamp: 2026-02-02
-    evidence: commit 38d4e96, PR #76/#92, app/src/indexer/ast-parser.ts, app/src/indexer/regex-fallback.ts
+    evidence: "commit 38d4e96, PR #76/#92, app/src/indexer/ast-parser.ts, app/src/indexer/regex-fallback.ts"
 
   extract_symbols:
     when: Extracting functions, classes, interfaces, types from AST
@@ -322,10 +309,10 @@ patterns:
       - Graceful fallback if no config found
 
     examples:
-      - "./utils" -> "/repo/src/utils.ts" (relative)
-      - "./api" -> "/repo/src/api/index.ts" (relative with index)
-      - "@api/routes" -> "/repo/src/api/routes.ts" (path alias)
-      - "lodash" -> null (node_modules, skip)
+      - '"./utils" -> "/repo/src/utils.ts" (relative)'
+      - '"./api" -> "/repo/src/api/index.ts" (relative with index)'
+      - '"@api/routes" -> "/repo/src/api/routes.ts" (path alias)'
+      - '"lodash" -> null (node_modules, skip)'
     pitfalls:
       - what: Resolving node_modules imports
         instead: Return null for non-relative, non-alias imports
@@ -371,8 +358,8 @@ patterns:
       - First-match-wins for multi-path mappings (e.g., monorepo fallbacks)
       - Graceful error handling (return null on parse errors)
     examples:
-      - "@api/routes" with { "@api/*": ["src/api/*"] } -> "/repo/src/api/routes.ts"
-      - "@shared/utils" with { "@shared/*": ["src/shared/*", "packages/shared/*"] } -> first match wins
+      - '"@api/routes" with { "@api/*": ["src/api/*"] } -> "/repo/src/api/routes.ts"'
+      - '"@shared/utils" with { "@shared/*": ["src/shared/*", "packages/shared/*"] } -> first match wins'
       - Child tsconfig extends parent -> merges path mappings
     pitfalls:
       - what: Not supporting tsconfig extends
@@ -552,7 +539,7 @@ patterns:
       - if: VariableDeclaration and isExported
         then: Extract variable/constant/function symbol
       - if: ExportNamedDeclaration or ExportDefaultDeclaration
-        then: Recurse into declaration with isExported: true
+        then: 'Recurse into declaration with isExported: true'
       - if: Other node type
         then: Skip (no symbol to extract)
 
@@ -588,7 +575,7 @@ patterns:
       - if: Still not found
         then: Try index file resolution
 
-error_recovery_strategy:
+  error_recovery_strategy:
     question: How should I handle parse errors for this file?
     options:
       - if: parseFileWithRecovery returns ast with partial:false
@@ -599,7 +586,7 @@ error_recovery_strategy:
         then: Use regex fallback (extractSymbolsWithRegex)
       - if: Regex fallback returns empty array
         then: Log error, skip file (no symbols available)
-      - if: Symbol has metadata.extractionMethod: "regex"
+      - if: 'Symbol has metadata.extractionMethod: "regex"'
         then: Use with caution (may lack JSDoc, accurate positions)
 
 patterns:
@@ -748,21 +735,24 @@ patterns:
     - Distinguish function calls from method calls
     - Track optional chaining (?.) in metadata
 
+
   import_resolution:
-    - Resolve relative imports (./ and ../) AND path aliases (@alias/*)
-    - Parse tsconfig.json once at indexing start (not per file)
-    - Pass pathMappings through entire resolution pipeline
-    - Try relative resolution first, then path alias resolution
-    - Return null for unresolvable imports (node_modules, missing configs)
-    - Use path.join + path.normalize (NOT path.resolve)
-    - Check files Set instead of filesystem (indexed files only)
-    - Support jsconfig.json fallback for JavaScript projects
-    - Handle extends recursively with circular detection
-    - Try extensions in priority order (.ts first)
-    - Handle index file resolution
-    - Preserve relative path structure for database matching
+    items:
+      - Resolve relative imports (./ and ../) AND path aliases (@alias/*)
+      - Parse tsconfig.json once at indexing start (not per file)
+      - Pass pathMappings through entire resolution pipeline
+      - Try relative resolution first, then path alias resolution
+      - Return null for unresolvable imports (node_modules, missing configs)
+      - Use path.join + path.normalize (NOT path.resolve)
+      - Check files Set instead of filesystem (indexed files only)
+      - Support jsconfig.json fallback for JavaScript projects
+      - Handle extends recursively with circular detection
+      - Try extensions in priority order (.ts first)
+      - Handle index file resolution
+      - Preserve relative path structure for database matching
     timestamp: 2026-01-29
-    evidence: app/src/indexer/import-resolver.ts, app/src/indexer/path-resolver.ts
+    evidence: "app/src/indexer/import-resolver.ts, app/src/indexer/path-resolver.ts"
+
   storage:
     - Use single transaction for atomicity
     - Build lookup maps for efficient foreign key resolution
@@ -770,16 +760,18 @@ patterns:
     - Log storage results for observability
 
   fts5_search:
-    - Always escape user search terms before FTS5 MATCH queries
-    - Wrap terms in double quotes for exact phrase matching
-    - Escape internal quotes by doubling them ("" not \")
-    - Prevents SQL errors on hyphens, spaces, AND/OR/NOT keywords
-    - Test with: hyphenated-terms, multi-word phrases, FTS keywords
+    items:
+      - Always escape user search terms before FTS5 MATCH queries
+      - Wrap terms in double quotes for exact phrase matching
+      - 'Escape internal quotes by doubling them ("" not \")'
+      - Prevents SQL errors on hyphens, spaces, AND/OR/NOT keywords
+      - "Test with: hyphenated-terms, multi-word phrases, FTS keywords"
     timestamp: 2026-01-28
     evidence: commit 5af086f
 
+
   logging:
-    - Use createLogger({ module: "indexer-<name>" })
+    - 'Use createLogger({ module: "indexer-<name>" })'
     - Log errors with structured metadata
     - Use debug level for expected failures (unresolved imports)
     - Use warn level for unexpected but recoverable failures
@@ -806,7 +798,7 @@ known_issues:
   - issue: Schema CHECK constraint must match all reference types
     impact: Insertion failures when reference extractor produces new types
     resolution: property_access was missing from CHECK constraint list
-    prevention: When adding reference types: update extractor, schema, tests
+    prevention: 'When adding reference types: update extractor, schema, tests'
     status: resolved
     timestamp: 2026-01-28
     evidence: commit 91415ad

--- a/.claude/agents/experts/testing/expertise.yaml
+++ b/.claude/agents/experts/testing/expertise.yaml
@@ -44,7 +44,7 @@ core_implementation:
     - pattern: describe/test blocks
       usage: Group related tests with describe, individual tests with test or it
     - pattern: In-memory SQLite
-      usage: createDatabase({ path: ":memory:" }) for fast isolated tests
+      usage: 'createDatabase({ path: ":memory:" }) for fast isolated tests'
     - pattern: beforeEach/afterEach
       usage: Setup and cleanup per test for isolation
     - pattern: Real implementations

--- a/.claude/hooks/kotadb/session-expertise.py
+++ b/.claude/hooks/kotadb/session-expertise.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""
+SessionStart hook for injecting dynamic expertise context at session start.
+
+This hook is triggered when a Claude Code session begins. It queries KotaDB
+for recent patterns and key files to provide domain-aware context that helps
+the agent understand the codebase state and recent activity.
+
+Hook Configuration (in .claude/settings.json):
+{
+  "hooks": {
+    "SessionStart": [{
+      "hooks": [{
+        "type": "command",
+        "command": "python3 .claude/hooks/kotadb/session-expertise.py"
+      }]
+    }]
+  }
+}
+
+Output (stdout):
+Dynamic expertise context including recent patterns and key files by domain.
+
+Exit codes:
+- 0: Success (always - don't block session start)
+"""
+
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timedelta
+from typing import Any
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from utils.hook_helpers import (
+    output_continue,
+    output_context,
+    get_kotadb_command,
+)
+
+
+# Domain mapping: directory prefixes to domain names
+DOMAIN_PREFIXES = {
+    "src/db/": "database",
+    "app/src/db/": "database",
+    "src/api/": "api",
+    "app/src/api/": "api",
+    "src/mcp/": "api",
+    "app/src/mcp/": "api",
+    "src/indexer/": "indexer",
+    "app/src/indexer/": "indexer",
+    ".claude/": "claude-config",
+    ".claude/agents/": "agent-authoring",
+    ".claude/hooks/": "claude-config",
+    ".claude/commands/": "claude-config",
+    "tests/": "testing",
+    "app/tests/": "testing",
+    "__tests__/": "testing",
+}
+
+
+def run_kotadb_search_patterns(limit: int = 10) -> dict[str, Any]:
+    """
+    Query KotaDB for recent patterns via MCP HTTP endpoint.
+    
+    Args:
+        limit: Maximum number of patterns to retrieve
+    
+    Returns:
+        Dict with results or error
+    """
+    try:
+        import urllib.request
+        import urllib.error
+        
+        mcp_url = os.environ.get("KOTADB_MCP_URL", "http://localhost:3000/mcp")
+        
+        request_data = {
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {
+                "name": "search_patterns",
+                "arguments": {"limit": limit},
+            },
+            "id": 1,
+        }
+        
+        req = urllib.request.Request(
+            mcp_url,
+            data=json.dumps(request_data).encode("utf-8"),
+            headers={
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            },
+            method="POST",
+        )
+        
+        with urllib.request.urlopen(req, timeout=5) as response:
+            result = json.loads(response.read().decode("utf-8"))
+            
+            if "error" in result:
+                return {"error": result["error"].get("message", "Unknown error")}
+            
+            content = result.get("result", {}).get("content", [])
+            if content and isinstance(content, list) and len(content) > 0:
+                text = content[0].get("text", "{}")
+                return json.loads(text)
+            
+            return {"results": []}
+    
+    except Exception as e:
+        return {"error": str(e)}
+
+
+def get_recent_git_files(days: int = 7, limit: int = 20) -> list[str]:
+    """
+    Get files changed in git within the last N days.
+    
+    Args:
+        days: Number of days to look back
+        limit: Maximum number of files to return
+    
+    Returns:
+        List of file paths
+    """
+    try:
+        since_date = (datetime.now() - timedelta(days=days)).strftime("%Y-%m-%d")
+        
+        result = subprocess.run(
+            ["git", "log", f"--since={since_date}", "--name-only", "--pretty=format:", "--diff-filter=AM"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            cwd=os.getcwd(),
+        )
+        
+        if result.returncode != 0:
+            return []
+        
+        # Parse unique files from output
+        files = set()
+        for line in result.stdout.strip().split("\n"):
+            line = line.strip()
+            if line and not line.startswith("."):
+                files.add(line)
+        
+        return list(files)[:limit]
+    
+    except Exception:
+        return []
+
+
+def get_key_files_by_domain() -> dict[str, list[dict[str, Any]]]:
+    """
+    Get key files organized by domain using KotaDB dependency data.
+    
+    Returns:
+        Dict mapping domain names to list of {file, dependents_count}
+    """
+    domain_files: dict[str, list[dict[str, Any]]] = {}
+    
+    # Get recently changed files
+    recent_files = get_recent_git_files(days=7, limit=30)
+    
+    if not recent_files:
+        # Fall back to common entry points
+        recent_files = [
+            "app/src/db/sqlite/index.ts",
+            "app/src/api/routes.ts",
+            "app/src/mcp/server.ts",
+            "app/src/indexer/bun-indexer.ts",
+        ]
+    
+    # Query dependencies for each file and categorize by domain
+    for file_path in recent_files:
+        # Determine domain
+        domain = "other"
+        for prefix, domain_name in DOMAIN_PREFIXES.items():
+            if file_path.startswith(prefix):
+                domain = domain_name
+                break
+        
+        if domain == "other":
+            continue  # Skip files outside known domains
+        
+        # Query KotaDB for dependents count
+        deps_result = run_kotadb_deps_count(file_path)
+        
+        if domain not in domain_files:
+            domain_files[domain] = []
+        
+        domain_files[domain].append({
+            "file": file_path,
+            "dependents_count": deps_result.get("dependents_count", 0),
+        })
+    
+    # Sort each domain by dependents count and limit
+    for domain in domain_files:
+        domain_files[domain] = sorted(
+            domain_files[domain],
+            key=lambda x: x["dependents_count"],
+            reverse=True,
+        )[:5]
+    
+    return domain_files
+
+
+def run_kotadb_deps_count(file_path: str) -> dict[str, Any]:
+    """
+    Get dependency count for a file via KotaDB CLI.
+    
+    Args:
+        file_path: Path to the file
+    
+    Returns:
+        Dict with dependents_count or error
+    """
+    try:
+        cmd = get_kotadb_command()
+        cmd.extend(["deps", "--file", file_path, "--format", "json", "--depth", "1"])
+        
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            cwd=os.getcwd(),
+        )
+        
+        if result.returncode != 0:
+            return {"dependents_count": 0}
+        
+        data = json.loads(result.stdout)
+        dependents = data.get("dependents", [])
+        
+        return {"dependents_count": len(dependents)}
+    
+    except Exception:
+        return {"dependents_count": 0}
+
+
+def format_session_context(
+    patterns: list[dict[str, Any]],
+    domain_files: dict[str, list[dict[str, Any]]],
+) -> str:
+    """
+    Format dynamic expertise context for session start.
+    
+    Args:
+        patterns: Recent patterns from KotaDB
+        domain_files: Key files organized by domain
+    
+    Returns:
+        Formatted markdown context string
+    """
+    lines = ["## Dynamic Expertise Context", ""]
+    
+    has_patterns = patterns and len(patterns) > 0
+    has_domain_files = domain_files and any(files for files in domain_files.values())
+    
+    if not has_patterns and not has_domain_files:
+        return ""  # No context to inject
+    
+    # Recent patterns section
+    if has_patterns:
+        lines.append("### Recent Patterns (last 7 days)")
+        for p in patterns[:10]:
+            pattern_type = p.get("pattern_type", "unknown")
+            file_path = p.get("file", "")
+            description = p.get("description", p.get("name", ""))
+            if len(description) > 60:
+                description = description[:57] + "..."
+            lines.append(f"- [{pattern_type}] in {file_path}: {description}")
+        lines.append("")
+    
+    # Key files by domain section
+    if has_domain_files:
+        lines.append("### Key Files by Domain")
+        
+        for domain in sorted(domain_files.keys()):
+            files = domain_files[domain]
+            if not files:
+                continue
+            
+            lines.append(f"**{domain}**:")
+            for f in files:
+                file_path = f["file"]
+                count = f["dependents_count"]
+                if count > 0:
+                    lines.append(f"- {file_path} ({count} dependents)")
+                else:
+                    lines.append(f"- {file_path}")
+            lines.append("")
+    
+    return "\n".join(lines)
+
+
+def main() -> None:
+    """Main hook entry point."""
+    # Query for recent patterns
+    patterns_result = run_kotadb_search_patterns(limit=10)
+    patterns = patterns_result.get("results", [])
+    
+    # Log warning if pattern search failed but continue
+    if patterns_result.get("error"):
+        sys.stderr.write(f"[kotadb-session] Warning: Pattern search failed: {patterns_result['error']}\n")
+    
+    # Get key files by domain
+    domain_files = get_key_files_by_domain()
+    
+    # Format and output context
+    context = format_session_context(patterns, domain_files)
+    
+    if context:
+        output_context(context)
+    else:
+        output_continue()
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,6 +30,12 @@
         "type": "command",
         "command": "python3 .claude/hooks/kotadb/agent-context.py"
       }]
+    }],
+    "SessionStart": [{
+      "hooks": [{
+        "type": "command",
+        "command": "python3 .claude/hooks/kotadb/session-expertise.py"
+      }]
     }]
   }
 }

--- a/app/src/api/expertise-queries.ts
+++ b/app/src/api/expertise-queries.ts
@@ -1,0 +1,274 @@
+/**
+ * Database queries for Dynamic Expertise feature
+ * 
+ * Provides domain-specific file discovery based on dependency graph analysis.
+ * Key files are identified by how many other files depend on them (dependents).
+ * 
+ * @module @api/expertise-queries
+ */
+
+import { getGlobalDatabase, type KotaDatabase } from "@db/sqlite/index.js";
+import { createLogger } from "@logging/logger.js";
+
+const logger = createLogger({ module: "expertise-queries" });
+
+/**
+ * Domain to path pattern mappings for expertise routing.
+ * 
+ * Each domain maps to an array of SQL LIKE patterns that identify
+ * files belonging to that domain within the repository.
+ */
+export const DOMAIN_PATH_PATTERNS: Record<string, string[]> = {
+	"database": [
+		"src/db/%",
+		"app/src/db/%",
+	],
+	"api": [
+		"src/api/%",
+		"src/mcp/%",
+		"app/src/api/%",
+		"app/src/mcp/%",
+	],
+	"indexer": [
+		"src/indexer/%",
+		"app/src/indexer/%",
+	],
+	"testing": [
+		"tests/%",
+		"app/tests/%",
+		"__tests__/%",
+	],
+	"claude-config": [
+		".claude/%",
+	],
+	"agent-authoring": [
+		".claude/agents/%",
+	],
+	"automation": [
+		".claude/commands/automation/%",
+	],
+	"github": [
+		".github/%",
+	],
+	"documentation": [
+		"web/docs/%",
+		"docs/%",
+	],
+};
+
+/**
+ * Result type for domain key files query
+ */
+export interface DomainKeyFile {
+	/** File path relative to repository root */
+	path: string;
+	/** Number of files that depend on this file */
+	dependentCount: number;
+	/** Repository ID the file belongs to */
+	repositoryId: string;
+}
+
+/**
+ * Get the most-depended-on files for a domain (key files).
+ * 
+ * Key files are identified by counting how many other files import them.
+ * This helps identify the core infrastructure files for each domain.
+ * 
+ * @param domain - Domain name (e.g., "database", "api", "indexer")
+ * @param limit - Maximum number of files to return (default: 10)
+ * @param repositoryId - Optional repository filter
+ * @returns Array of key files sorted by dependent count (descending)
+ * 
+ * @example
+ * ```ts
+ * const keyFiles = getDomainKeyFiles("database", 5);
+ * // Returns top 5 most-imported files from src/db/
+ * ```
+ */
+export function getDomainKeyFiles(
+	domain: string,
+	limit: number = 10,
+	repositoryId?: string,
+): DomainKeyFile[] {
+	const db = getGlobalDatabase();
+	return getDomainKeyFilesInternal(db, domain, limit, repositoryId);
+}
+
+/**
+ * Internal implementation that accepts a database parameter.
+ * Used for testing with injected database instances.
+ */
+function getDomainKeyFilesInternal(
+	db: KotaDatabase,
+	domain: string,
+	limit: number = 10,
+	repositoryId?: string,
+): DomainKeyFile[] {
+	const patterns = DOMAIN_PATH_PATTERNS[domain];
+	
+	if (!patterns || patterns.length === 0) {
+		logger.warn("Unknown domain or no patterns defined", { domain });
+		return [];
+	}
+	
+	// Build WHERE clause for path patterns
+	const pathConditions = patterns.map(() => "f.path LIKE ?").join(" OR ");
+	
+	// Build repository filter condition
+	const repoCondition = repositoryId ? "AND f.repository_id = ?" : "";
+	
+	const sql = `
+		SELECT 
+			f.path,
+			f.repository_id,
+			COUNT(DISTINCT r.file_id) AS dependent_count
+		FROM indexed_files f
+		JOIN indexed_references r ON f.path = r.target_file_path
+		WHERE r.reference_type = 'import'
+			AND (${pathConditions})
+			${repoCondition}
+		GROUP BY f.id
+		ORDER BY dependent_count DESC
+		LIMIT ?
+	`;
+	
+	// Build params array
+	const params: (string | number)[] = [...patterns];
+	if (repositoryId) {
+		params.push(repositoryId);
+	}
+	params.push(limit);
+	
+	const rows = db.query<{
+		path: string;
+		repository_id: string;
+		dependent_count: number;
+	}>(sql, params);
+	
+	logger.debug("Retrieved domain key files", {
+		domain,
+		count: rows.length,
+		limit,
+		repositoryId,
+	});
+	
+	return rows.map(row => ({
+		path: row.path,
+		dependentCount: row.dependent_count,
+		repositoryId: row.repository_id,
+	}));
+}
+
+/**
+ * Get all files for a domain (without dependency ranking).
+ * 
+ * Returns all indexed files matching the domain's path patterns.
+ * Useful when you need the full list rather than just key files.
+ * 
+ * @param domain - Domain name
+ * @param limit - Maximum number of files (default: 100)
+ * @param repositoryId - Optional repository filter
+ * @returns Array of file paths
+ */
+export function getDomainFiles(
+	domain: string,
+	limit: number = 100,
+	repositoryId?: string,
+): string[] {
+	const db = getGlobalDatabase();
+	return getDomainFilesInternal(db, domain, limit, repositoryId);
+}
+
+/**
+ * Internal implementation for getDomainFiles.
+ */
+function getDomainFilesInternal(
+	db: KotaDatabase,
+	domain: string,
+	limit: number = 100,
+	repositoryId?: string,
+): string[] {
+	const patterns = DOMAIN_PATH_PATTERNS[domain];
+	
+	if (!patterns || patterns.length === 0) {
+		logger.warn("Unknown domain or no patterns defined", { domain });
+		return [];
+	}
+	
+	const pathConditions = patterns.map(() => "path LIKE ?").join(" OR ");
+	const repoCondition = repositoryId ? "AND repository_id = ?" : "";
+	
+	const sql = `
+		SELECT path
+		FROM indexed_files
+		WHERE (${pathConditions})
+			${repoCondition}
+		ORDER BY indexed_at DESC
+		LIMIT ?
+	`;
+	
+	const params: (string | number)[] = [...patterns];
+	if (repositoryId) {
+		params.push(repositoryId);
+	}
+	params.push(limit);
+	
+	const rows = db.query<{ path: string }>(sql, params);
+	
+	return rows.map(row => row.path);
+}
+
+/**
+ * Get available domains that have indexed files.
+ * 
+ * Checks which domains have at least one file matching their patterns.
+ * Useful for determining which expertise areas are available.
+ * 
+ * @param repositoryId - Optional repository filter
+ * @returns Array of domain names that have files
+ */
+export function getAvailableDomains(repositoryId?: string): string[] {
+	const db = getGlobalDatabase();
+	const availableDomains: string[] = [];
+	
+	for (const domain of Object.keys(DOMAIN_PATH_PATTERNS)) {
+		const files = getDomainFilesInternal(db, domain, 1, repositoryId);
+		if (files.length > 0) {
+			availableDomains.push(domain);
+		}
+	}
+	
+	logger.debug("Retrieved available domains", {
+		count: availableDomains.length,
+		domains: availableDomains,
+		repositoryId,
+	});
+	
+	return availableDomains;
+}
+
+/**
+ * @deprecated Use getDomainKeyFiles() directly
+ * Backward-compatible alias that accepts db parameter for testing.
+ */
+export function getDomainKeyFilesLocal(
+	db: KotaDatabase,
+	domain: string,
+	limit: number = 10,
+	repositoryId?: string,
+): DomainKeyFile[] {
+	return getDomainKeyFilesInternal(db, domain, limit, repositoryId);
+}
+
+/**
+ * @deprecated Use getDomainFiles() directly
+ * Backward-compatible alias that accepts db parameter for testing.
+ */
+export function getDomainFilesLocal(
+	db: KotaDatabase,
+	domain: string,
+	limit: number = 100,
+	repositoryId?: string,
+): string[] {
+	return getDomainFilesInternal(db, domain, limit, repositoryId);
+}

--- a/app/src/cli.ts
+++ b/app/src/cli.ts
@@ -50,6 +50,7 @@ kotadb v${version} - Local code intelligence for CLI agents
 USAGE:
   kotadb [OPTIONS]
   kotadb deps [OPTIONS]
+  kotadb expertise [OPTIONS]
 
 COMMANDS:
   deps              Query dependency information for a file
@@ -59,6 +60,12 @@ COMMANDS:
                       --depth, -d <n>       Dependency traversal depth 1-5 (default: 1)
                       --include-tests       Include test files in output
                       --repository, -r <id> Repository ID or full_name
+
+  expertise         Manage expert domain knowledge
+                    Subcommands:
+                      sync --domain <d>     Sync patterns to database
+                      validate --domain <d> Check for stale patterns
+                      key-files --domain <d> List key files with dependents
 
 OPTIONS:
   --stdio           Use stdio transport (for Claude Code integration)
@@ -201,6 +208,13 @@ async function main(): Promise<void> {
     // Handle deps subcommand
     const { runDepsCommand } = await import("./cli/deps.js");
     runDepsCommand(args.slice(1));
+    return;
+  }
+
+  if (firstArg === "expertise") {
+    // Handle expertise subcommand
+    const { runExpertiseCommand } = await import("./cli/expertise.js");
+    runExpertiseCommand(args.slice(1));
     return;
   }
 

--- a/app/src/cli/expertise.ts
+++ b/app/src/cli/expertise.ts
@@ -1,0 +1,495 @@
+/**
+ * CLI expertise command implementation
+ *
+ * Manages expertise.yaml files for expert domains.
+ *
+ * Usage:
+ *   kotadb expertise sync --domain <domain>
+ *   kotadb expertise validate --domain <domain>
+ *   kotadb expertise key-files --domain <domain>
+ *
+ * @module cli/expertise
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { parse as parseYaml } from "yaml";
+import { getGlobalDatabase } from "@db/sqlite/index.js";
+import { resolveRepositoryIdentifierWithError } from "@mcp/repository-resolver";
+import { queryDependents, resolveFilePath } from "@api/queries";
+
+export interface ExpertiseOptions {
+	subcommand: "sync" | "validate" | "key-files";
+	domain?: string;
+	help?: boolean;
+}
+
+interface KeyFileEntry {
+	path: string;
+	purpose: string;
+	exports?: string;
+	patterns?: string;
+}
+
+interface ExpertiseYaml {
+	overview?: {
+		description?: string;
+		scope?: string;
+		rationale?: string;
+	};
+	core_implementation?: {
+		key_files?: KeyFileEntry[];
+	};
+	key_operations?: Record<string, {
+		when?: string;
+		approach?: string;
+		pattern?: string;
+		timestamp?: string;
+		evidence?: string;
+		rationale?: string;
+	}>;
+	patterns?: Record<string, {
+		structure?: string;
+		notes?: string[];
+		timestamp?: string;
+		evidence?: string;
+	}>;
+	best_practices?: Record<string, string>;
+	known_issues?: Array<{
+		issue: string;
+		impact?: string;
+		status?: string;
+		resolution?: string;
+	}>;
+}
+
+const EXPERTS_BASE_PATH = ".claude/agents/experts";
+const VALID_DOMAINS = [
+	"api",
+	"agent-authoring",
+	"automation",
+	"claude-config",
+	"database",
+	"documentation",
+	"github",
+	"indexer",
+	"testing",
+];
+
+/**
+ * Print expertise command help
+ */
+function printExpertiseHelp(): void {
+	const help = `
+kotadb expertise - Manage expert domain knowledge
+
+USAGE:
+  kotadb expertise <subcommand> [OPTIONS]
+
+SUBCOMMANDS:
+  sync          Sync patterns from expertise.yaml to database
+  validate      Validate expertise.yaml patterns for staleness
+  key-files     List key files with dependent counts
+
+OPTIONS:
+  --domain, -d <name>   Expert domain to operate on (required)
+  --help, -h            Show this help message
+
+AVAILABLE DOMAINS:
+  api             HTTP endpoints, MCP tools, Express patterns
+  agent-authoring Agent creation, frontmatter, tools, registry
+  automation      ADW workflows, agent orchestration
+  claude-config   .claude/ configuration (commands, hooks, settings)
+  database        SQLite schema, FTS5, migrations, queries
+  documentation   Documentation management, content organization
+  github          Issues, PRs, branches, GitHub CLI workflows
+  indexer         AST parsing, symbol extraction, code analysis
+  testing         Antimocking, Bun tests, SQLite test patterns
+
+EXAMPLES:
+  kotadb expertise sync --domain database
+  kotadb expertise validate --domain api
+  kotadb expertise key-files --domain indexer
+  kotadb expertise key-files -d testing
+
+`;
+	process.stdout.write(help);
+}
+
+/**
+ * Parse expertise command arguments
+ */
+export function parseExpertiseArgs(args: string[]): ExpertiseOptions | { error: string } | { help: true } {
+	if (args.length === 0) {
+		return { help: true };
+	}
+
+	const subcommand = args[0];
+	if (subcommand === "--help" || subcommand === "-h") {
+		return { help: true };
+	}
+
+	if (!["sync", "validate", "key-files"].includes(subcommand as string)) {
+		return { error: "Error: Unknown subcommand: " + subcommand + ". Use sync, validate, or key-files." };
+	}
+
+	const options: ExpertiseOptions = {
+		subcommand: subcommand as "sync" | "validate" | "key-files",
+	};
+
+	for (let i = 1; i < args.length; i++) {
+		const arg = args[i];
+		if (arg === undefined) continue;
+
+		if (arg === "--help" || arg === "-h") {
+			return { help: true };
+		} else if (arg === "--domain" || arg === "-d") {
+			const value = args[++i];
+			if (!value || value.startsWith("-")) {
+				return { error: "Error: --domain requires a domain name" };
+			}
+			options.domain = value;
+		} else if (arg.startsWith("--domain=")) {
+			const value = arg.split("=")[1];
+			if (!value) {
+				return { error: "Error: --domain requires a domain name" };
+			}
+			options.domain = value;
+		} else if (arg.startsWith("-") && arg !== "-") {
+			return { error: "Error: Unknown option: " + arg };
+		}
+	}
+
+	if (!options.domain) {
+		return { error: "Error: --domain is required" };
+	}
+
+	if (!VALID_DOMAINS.includes(options.domain)) {
+		return { error: "Error: Unknown domain: " + options.domain + ". Valid domains: " + VALID_DOMAINS.join(", ") };
+	}
+
+	return options;
+}
+
+/**
+ * Find project root by looking for .git directory
+ */
+function findProjectRoot(): string {
+	let current = process.cwd();
+	while (current !== "/") {
+		if (existsSync(join(current, ".git"))) {
+			return current;
+		}
+		current = resolve(current, "..");
+	}
+	return process.cwd();
+}
+
+/**
+ * Load expertise.yaml for a domain
+ */
+function loadExpertiseYaml(domain: string): ExpertiseYaml | { error: string } {
+	const projectRoot = findProjectRoot();
+	const expertisePath = join(projectRoot, EXPERTS_BASE_PATH, domain, "expertise.yaml");
+
+	if (!existsSync(expertisePath)) {
+		return { error: "Expertise file not found: " + expertisePath };
+	}
+
+	try {
+		const content = readFileSync(expertisePath, "utf-8");
+		return parseYaml(content) as ExpertiseYaml;
+	} catch (err) {
+		return { error: "Failed to parse expertise.yaml: " + (err instanceof Error ? err.message : String(err)) };
+	}
+}
+
+/**
+ * Execute sync subcommand
+ */
+function executeSync(domain: string): { success: boolean; message: string; count?: number } {
+	const expertise = loadExpertiseYaml(domain);
+	if ("error" in expertise) {
+		return { success: false, message: expertise.error };
+	}
+
+	const db = getGlobalDatabase();
+	let syncedCount = 0;
+	const { randomUUID } = require("node:crypto");
+
+	if (expertise.key_operations) {
+		for (const [name, op] of Object.entries(expertise.key_operations)) {
+			const existingDecision = db.queryOne<{ id: string }>(
+				"SELECT id FROM decisions WHERE title = ? AND scope = ?",
+				[domain + ":" + name, "pattern"],
+			);
+
+			const context = op.when || "";
+			const decision = op.approach || op.pattern || "";
+			const rationale = op.rationale || "";
+
+			if (existingDecision) {
+				db.run(
+					"UPDATE decisions SET context = ?, decision = ?, rationale = ?, updated_at = datetime('now') WHERE id = ?",
+					[context, decision, rationale, existingDecision.id],
+				);
+			} else {
+				db.run(
+					"INSERT INTO decisions (id, title, context, decision, scope, rationale, created_at, updated_at) VALUES (?, ?, ?, ?, 'pattern', ?, datetime('now'), datetime('now'))",
+					[randomUUID(), domain + ":" + name, context, decision, rationale],
+				);
+			}
+			syncedCount++;
+		}
+	}
+
+	if (expertise.patterns) {
+		for (const [name, pattern] of Object.entries(expertise.patterns)) {
+			const existingDecision = db.queryOne<{ id: string }>(
+				"SELECT id FROM decisions WHERE title = ? AND scope = ?",
+				[domain + ":pattern:" + name, "convention"],
+			);
+
+			const context = pattern.notes?.join("\n") || "";
+			const decision = pattern.structure || "";
+
+			if (existingDecision) {
+				db.run(
+					"UPDATE decisions SET context = ?, decision = ?, updated_at = datetime('now') WHERE id = ?",
+					[context, decision, existingDecision.id],
+				);
+			} else {
+				db.run(
+					"INSERT INTO decisions (id, title, context, decision, scope, created_at, updated_at) VALUES (?, ?, ?, ?, 'convention', datetime('now'), datetime('now'))",
+					[randomUUID(), domain + ":pattern:" + name, context, decision],
+				);
+			}
+			syncedCount++;
+		}
+	}
+
+	if (expertise.known_issues) {
+		for (const issue of expertise.known_issues) {
+			const searchTerm = issue.issue.substring(0, 50);
+			const existingInsight = db.queryOne<{ id: string }>(
+				"SELECT id FROM insights WHERE content LIKE ?",
+				["%" + searchTerm + "%"],
+			);
+
+			if (!existingInsight) {
+				const content = "[" + domain + "] " + issue.issue + "\nImpact: " + (issue.impact || "Unknown") + "\nStatus: " + (issue.status || "Unknown") + "\nResolution: " + (issue.resolution || "None");
+				const insightType = issue.status === "resolved" ? "workaround" : "discovery";
+				db.run(
+					"INSERT INTO insights (id, content, insight_type, created_at) VALUES (?, ?, ?, datetime('now'))",
+					[randomUUID(), content, insightType],
+				);
+				syncedCount++;
+			}
+		}
+	}
+
+	return {
+		success: true,
+		message: "Synced " + syncedCount + " patterns from " + domain + " expertise",
+		count: syncedCount,
+	};
+}
+
+/**
+ * Execute validate subcommand
+ */
+function executeValidate(domain: string): { success: boolean; message: string; results?: Array<{ name: string; status: string; lastUpdated: string }> } {
+	const expertise = loadExpertiseYaml(domain);
+	if ("error" in expertise) {
+		return { success: false, message: expertise.error };
+	}
+
+	const results: Array<{ name: string; status: string; lastUpdated: string }> = [];
+	const now = new Date();
+	const sixMonthsAgo = new Date(now.getTime() - 180 * 24 * 60 * 60 * 1000);
+
+	if (expertise.key_operations) {
+		for (const [name, op] of Object.entries(expertise.key_operations)) {
+			let status = "valid";
+			const timestamp = op.timestamp || "unknown";
+
+			if (timestamp === "unknown") {
+				status = "no-date";
+			} else {
+				const opDate = new Date(timestamp);
+				if (opDate < sixMonthsAgo) {
+					status = "stale";
+				}
+			}
+
+			results.push({ name, status, lastUpdated: timestamp });
+		}
+	}
+
+	if (expertise.patterns) {
+		for (const [name, pattern] of Object.entries(expertise.patterns)) {
+			let status = "valid";
+			const timestamp = pattern.timestamp || "unknown";
+
+			if (timestamp === "unknown") {
+				status = "no-date";
+			} else {
+				const patternDate = new Date(timestamp);
+				if (patternDate < sixMonthsAgo) {
+					status = "stale";
+				}
+			}
+
+			results.push({ name: "pattern:" + name, status, lastUpdated: timestamp });
+		}
+	}
+
+	const staleCount = results.filter((r) => r.status === "stale").length;
+	const noDateCount = results.filter((r) => r.status === "no-date").length;
+	const validCount = results.filter((r) => r.status === "valid").length;
+
+	return {
+		success: true,
+		message: "Validated " + results.length + " patterns: " + validCount + " valid, " + staleCount + " stale, " + noDateCount + " missing date",
+		results,
+	};
+}
+
+/**
+ * Execute key-files subcommand
+ */
+function executeKeyFiles(domain: string): { success: boolean; message: string; results?: Array<{ path: string; dependents: number; purpose: string }> } {
+	const expertise = loadExpertiseYaml(domain);
+	if ("error" in expertise) {
+		return { success: false, message: expertise.error };
+	}
+
+	const keyFiles = expertise.core_implementation?.key_files;
+	if (!keyFiles || keyFiles.length === 0) {
+		return { success: false, message: "No key files defined in " + domain + " expertise.yaml" };
+	}
+
+	const results: Array<{ path: string; dependents: number; purpose: string }> = [];
+
+	const repoResult = resolveRepositoryIdentifierWithError(undefined);
+	const hasRepo = !("error" in repoResult);
+	const repositoryId = hasRepo ? repoResult.id : null;
+
+	for (const file of keyFiles) {
+		let dependentCount = 0;
+
+		if (repositoryId) {
+			const fileId = resolveFilePath(file.path, repositoryId);
+			if (fileId) {
+				const dependents = queryDependents(fileId, 1, false);
+				dependentCount = dependents.direct.length;
+			}
+		}
+
+		results.push({
+			path: file.path,
+			dependents: dependentCount,
+			purpose: file.purpose || "No purpose specified",
+		});
+	}
+
+	results.sort((a, b) => b.dependents - a.dependents);
+
+	return {
+		success: true,
+		message: "Found " + results.length + " key files in " + domain + " expertise",
+		results,
+	};
+}
+
+/**
+ * Format validation results as table
+ */
+function formatValidationTable(results: Array<{ name: string; status: string; lastUpdated: string }>): string {
+	const lines: string[] = [];
+	const nameWidth = Math.max(20, ...results.map((r) => r.name.length));
+
+	lines.push("Pattern".padEnd(nameWidth) + "  " + "Status".padEnd(10) + "  " + "Last Updated");
+	lines.push("-".repeat(nameWidth + 30));
+
+	for (const result of results) {
+		const statusDisplay = result.status === "valid" ? "valid" : result.status === "stale" ? "STALE" : "NO DATE";
+		lines.push(result.name.padEnd(nameWidth) + "  " + statusDisplay.padEnd(10) + "  " + result.lastUpdated);
+	}
+
+	return lines.join("\n");
+}
+
+/**
+ * Format key files results as table
+ */
+function formatKeyFilesTable(results: Array<{ path: string; dependents: number; purpose: string }>): string {
+	const lines: string[] = [];
+	const pathWidth = Math.max(35, ...results.map((r) => r.path.length));
+
+	lines.push("File".padEnd(pathWidth) + "  " + "Dependents".padEnd(10) + "  " + "Purpose");
+	lines.push("-".repeat(pathWidth + 60));
+
+	for (const result of results) {
+		const purposeTruncated = result.purpose.length > 40 ? result.purpose.substring(0, 37) + "..." : result.purpose;
+		lines.push(result.path.padEnd(pathWidth) + "  " + String(result.dependents).padEnd(10) + "  " + purposeTruncated);
+	}
+
+	return lines.join("\n");
+}
+
+/**
+ * Run expertise command
+ */
+export function runExpertiseCommand(args: string[]): void {
+	const parseResult = parseExpertiseArgs(args);
+
+	if ("help" in parseResult && parseResult.help) {
+		printExpertiseHelp();
+		process.exit(0);
+	}
+
+	if ("error" in parseResult) {
+		process.stderr.write(parseResult.error + "\n");
+		process.stderr.write("Usage: kotadb expertise <sync|validate|key-files> --domain <domain>\n");
+		process.exit(1);
+	}
+
+	const { subcommand, domain } = parseResult as ExpertiseOptions;
+
+	if (!domain) {
+		process.stderr.write("Error: --domain is required\n");
+		process.exit(1);
+	}
+
+	let result: { success: boolean; message: string; results?: unknown };
+
+	switch (subcommand) {
+		case "sync":
+			result = executeSync(domain);
+			break;
+		case "validate":
+			result = executeValidate(domain);
+			break;
+		case "key-files":
+			result = executeKeyFiles(domain);
+			break;
+	}
+
+	if (!result.success) {
+		process.stderr.write(result.message + "\n");
+		process.exit(1);
+	}
+
+	process.stdout.write(result.message + "\n");
+
+	if (subcommand === "validate" && result.results) {
+		process.stdout.write("\n");
+		process.stdout.write(formatValidationTable(result.results as Array<{ name: string; status: string; lastUpdated: string }>) + "\n");
+	}
+
+	if (subcommand === "key-files" && result.results) {
+		process.stdout.write("\n");
+		process.stdout.write(formatKeyFilesTable(result.results as Array<{ path: string; dependents: number; purpose: string }>) + "\n");
+	}
+}

--- a/app/src/mcp/server.ts
+++ b/app/src/mcp/server.ts
@@ -30,6 +30,11 @@ import {
 	RECORD_FAILURE_TOOL,
 	SEARCH_PATTERNS_TOOL,
 	RECORD_INSIGHT_TOOL,
+	// Dynamic Expertise tools
+	GET_DOMAIN_KEY_FILES_TOOL,
+	VALIDATE_EXPERTISE_TOOL,
+	SYNC_EXPERTISE_TOOL,
+	GET_RECENT_PATTERNS_TOOL,
 	// Execute functions
 	executeAnalyzeChangeImpact,
 	executeGenerateTaskContext,
@@ -47,6 +52,11 @@ import {
 	executeRecordFailure,
 	executeSearchPatterns,
 	executeRecordInsight,
+	// Dynamic Expertise execute functions
+	executeGetDomainKeyFiles,
+	executeValidateExpertise,
+	executeSyncExpertise,
+	executeGetRecentPatterns,
 } from "./tools";
 
 const logger = createLogger({ module: "mcp-server" });
@@ -79,6 +89,10 @@ export interface McpServerContext {
  * - record_failure: Record a failed approach
  * - search_patterns: Find codebase patterns
  * - record_insight: Store a session insight
+ * - get_domain_key_files: Get most-depended-on files for a domain
+ * - validate_expertise: Validate expertise.yaml patterns against indexed code
+ * - sync_expertise: Sync patterns from expertise.yaml to patterns table
+ * - get_recent_patterns: Get recently observed patterns
  */
 export function createMcpServer(context: McpServerContext): Server {
 	const server = new Server(
@@ -113,6 +127,11 @@ export function createMcpServer(context: McpServerContext): Server {
 				RECORD_FAILURE_TOOL,
 				SEARCH_PATTERNS_TOOL,
 				RECORD_INSIGHT_TOOL,
+				// Dynamic Expertise tools
+				GET_DOMAIN_KEY_FILES_TOOL,
+				VALIDATE_EXPERTISE_TOOL,
+				SYNC_EXPERTISE_TOOL,
+				GET_RECENT_PATTERNS_TOOL,
 			],
 		};
 	});
@@ -220,6 +239,35 @@ export function createMcpServer(context: McpServerContext): Server {
 					break;
 				case "record_insight":
 					result = await executeRecordInsight(
+						toolArgs,
+						"", // requestId not used
+						context.userId,
+					);
+					break;
+				// Dynamic Expertise tools
+				case "get_domain_key_files":
+					result = await executeGetDomainKeyFiles(
+						toolArgs,
+						"", // requestId not used
+						context.userId,
+					);
+					break;
+				case "validate_expertise":
+					result = await executeValidateExpertise(
+						toolArgs,
+						"", // requestId not used
+						context.userId,
+					);
+					break;
+				case "sync_expertise":
+					result = await executeSyncExpertise(
+						toolArgs,
+						"", // requestId not used
+						context.userId,
+					);
+					break;
+				case "get_recent_patterns":
+					result = await executeGetRecentPatterns(
 						toolArgs,
 						"", // requestId not used
 						context.userId,


### PR DESCRIPTION
## Summary

Implements Phase 3: Dynamic Expertise (Issue #100) - replacing static YAML maintenance with KotaDB-derived content.

- **4 new MCP tools** for expertise management
- **3 CLI commands** for sync/validate/key-files
- **SessionStart hook** for dynamic context injection

## Changes

### New MCP Tools
| Tool | Purpose |
|------|---------|
| `get_domain_key_files` | Get most-depended-on files by domain |
| `validate_expertise` | Validate expertise.yaml patterns exist in code |
| `sync_expertise` | Sync patterns from YAML to database |
| `get_recent_patterns` | Query recently observed patterns |

### New CLI Commands
```bash
bunx kotadb expertise sync --domain database
bunx kotadb expertise validate --domain api
bunx kotadb expertise key-files --domain indexer
```

### SessionStart Hook
`.claude/hooks/kotadb/session-expertise.py` injects:
- Recent patterns (last 7 days)
- Key files by domain with dependent counts

## Files Changed

| File | Lines | Purpose |
|------|-------|---------|
| `app/src/api/expertise-queries.ts` | +274 | Domain key files SQL queries |
| `app/src/cli/expertise.ts` | +495 | CLI command implementation |
| `app/src/mcp/tools.ts` | +550 | 4 MCP tool definitions + executors |
| `.claude/hooks/kotadb/session-expertise.py` | +324 | SessionStart hook |
| `.claude/settings.json` | +6 | Hook registration |
| `app/src/cli.ts` | +14 | CLI routing |

## Test plan

- [x] TypeScript compiles without errors
- [x] All 784 tests pass
- [x] Pre-commit hooks pass (type-check + lint)
- [ ] Manual test: `bunx kotadb expertise key-files --domain database`
- [ ] Manual test: `bunx kotadb expertise validate --domain api`
- [ ] Manual test: `bunx kotadb expertise sync --domain testing`

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)