### PR TITLE
docs: comprehensive documentation update for v2.0.1 release

### DIFF
--- a/web/docs/content/api-reference.md
+++ b/web/docs/content/api-reference.md
@@ -2,8 +2,8 @@
 title: API Reference
 description: KotaDB MCP tools and HTTP endpoints
 order: 3
-last_updated: 2026-01-30
-version: 2.0.0
+last_updated: 2026-02-03
+version: 2.0.1
 reviewed_by: documentation-build-agent
 ---
 
@@ -88,6 +88,7 @@ Search the dependency graph to find related files.
 - `direction` (optional): `dependents`, `dependencies`, or `both` (default: `both`)
 - `depth` (optional): Recursion depth 1-5 (default: 1)
 - `include_tests` (optional): Include test files (default: true)
+- `reference_types` (optional): Array of reference types to filter by (default: `["import", "re_export", "export_all"]`)
 
 **Example:**
 ```json
@@ -113,6 +114,7 @@ Analyze the impact of proposed code changes.
 - `files_to_create` (optional): List of files to be created
 - `files_to_delete` (optional): List of files to be deleted
 - `breaking_changes` (optional): Whether this includes breaking changes
+- `repository` (optional): Repository ID to analyze
 
 **Example:**
 ```json
@@ -194,6 +196,270 @@ Import JSONL files into local SQLite database.
 ```
 
 **Returns:** Import summary with tables imported, rows imported, errors, and duration.
+
+---
+
+### generate_task_context
+
+Generate structured context for a set of files including dependency counts, impacted files, test files, and recent changes. Designed for hook-based context injection with <100ms performance target.
+
+**Parameters:**
+- `files` (required): List of file paths to analyze (relative to repository root)
+- `include_tests` (optional): Include test file discovery (default: true)
+- `include_symbols` (optional): Include symbol information for each file (default: false)
+- `max_impacted_files` (optional): Maximum number of impacted files to return (default: 20)
+- `repository` (optional): Repository ID or full_name
+
+**Example:**
+```json
+{
+  "files": ["src/api/routes.ts", "src/db/queries.ts"],
+  "include_tests": true,
+  "include_symbols": false,
+  "max_impacted_files": 15
+}
+```
+
+**Returns:** Structured context including target files with dependent counts, impacted files, test files, recent changes, and index staleness status.
+
+---
+
+## Memory Layer Tools
+
+Tools for recording and searching architectural decisions, failed approaches, patterns, and session insights to build cross-session intelligence.
+
+### search_decisions
+
+Search past architectural decisions using FTS5 full-text search.
+
+**Parameters:**
+- `query` (required): Search query for decisions
+- `scope` (optional): Filter by decision scope (`architecture`, `pattern`, `convention`, `workaround`)
+- `repository` (optional): Filter to a specific repository ID or full_name
+- `limit` (optional): Maximum results (default: 20)
+
+**Example:**
+```json
+{
+  "query": "database migration",
+  "scope": "architecture",
+  "limit": 10
+}
+```
+
+**Returns:** Matching decisions with relevance scores, including title, context, decision, rationale, alternatives, and related files.
+
+---
+
+### record_decision
+
+Record a new architectural decision for future reference.
+
+**Parameters:**
+- `title` (required): Decision title/summary
+- `context` (required): Context and background for the decision
+- `decision` (required): The actual decision made
+- `scope` (optional): Decision scope/category (default: `pattern`). One of: `architecture`, `pattern`, `convention`, `workaround`
+- `rationale` (optional): Why this decision was made
+- `alternatives` (optional): Array of alternatives that were considered
+- `related_files` (optional): Array of related file paths
+- `repository` (optional): Repository ID or full_name
+
+**Example:**
+```json
+{
+  "title": "Use SQLite for local storage",
+  "context": "Need persistent storage for indexed code files",
+  "decision": "Use SQLite with FTS5 for full-text search capabilities",
+  "scope": "architecture",
+  "rationale": "SQLite is embedded, requires no setup, and FTS5 provides excellent search",
+  "alternatives": ["PostgreSQL", "LevelDB", "File-based JSON"],
+  "related_files": ["src/db/sqlite/index.ts"]
+}
+```
+
+**Returns:** Success status with the created decision ID.
+
+---
+
+### search_failures
+
+Search failed approaches to avoid repeating mistakes.
+
+**Parameters:**
+- `query` (required): Search query for failures
+- `repository` (optional): Filter to a specific repository ID or full_name
+- `limit` (optional): Maximum results (default: 20)
+
+**Example:**
+```json
+{
+  "query": "circular dependency",
+  "limit": 5
+}
+```
+
+**Returns:** Matching failures with relevance scores, including title, problem, approach, failure reason, and related files.
+
+---
+
+### record_failure
+
+Record a failed approach for future reference. Helps agents avoid repeating mistakes.
+
+**Parameters:**
+- `title` (required): Failure title/summary
+- `problem` (required): The problem being solved
+- `approach` (required): The approach that was tried
+- `failure_reason` (required): Why the approach failed
+- `related_files` (optional): Array of related file paths
+- `repository` (optional): Repository ID or full_name
+
+**Example:**
+```json
+{
+  "title": "Recursive import resolution caused stack overflow",
+  "problem": "Resolving deeply nested import chains",
+  "approach": "Used recursive function without depth limit",
+  "failure_reason": "Stack overflow on circular dependencies exceeding 1000 levels",
+  "related_files": ["src/indexer/resolver.ts"]
+}
+```
+
+**Returns:** Success status with the created failure ID.
+
+---
+
+### search_patterns
+
+Find codebase patterns by type or file. Returns discovered patterns for consistency.
+
+**Parameters:**
+- `query` (optional): Search query for pattern name/description
+- `pattern_type` (optional): Filter by pattern type (e.g., `error-handling`, `api-call`)
+- `file` (optional): Filter by file path
+- `repository` (optional): Filter to a specific repository ID or full_name
+- `limit` (optional): Maximum results (default: 20)
+
+**Example:**
+```json
+{
+  "pattern_type": "error-handling",
+  "limit": 10
+}
+```
+
+**Returns:** Matching patterns including pattern type, file path, description, and example.
+
+---
+
+### record_insight
+
+Store a session insight for future agents. Insights are discoveries, failures, or workarounds.
+
+**Parameters:**
+- `content` (required): The insight content
+- `insight_type` (required): Type of insight (`discovery`, `failure`, `workaround`)
+- `session_id` (optional): Session identifier for grouping
+- `related_file` (optional): Related file path
+- `repository` (optional): Repository ID or full_name
+
+**Example:**
+```json
+{
+  "content": "The AST parser needs explicit handling for TypeScript decorators",
+  "insight_type": "discovery",
+  "related_file": "src/indexer/ast-parser.ts"
+}
+```
+
+**Returns:** Success status with the created insight ID.
+
+---
+
+## Dynamic Expertise Tools
+
+Tools for working with domain expertise definitions and discovering key files in the codebase.
+
+### get_domain_key_files
+
+Get the most-depended-on files for a domain. Key files are core infrastructure that many other files depend on.
+
+**Parameters:**
+- `domain` (required): Domain name (e.g., `database`, `api`, `indexer`, `testing`, `claude-config`, `agent-authoring`, `automation`, `github`, `documentation`)
+- `limit` (optional): Maximum number of files to return (default: 10)
+- `repository` (optional): Filter to a specific repository ID
+
+**Example:**
+```json
+{
+  "domain": "database",
+  "limit": 5
+}
+```
+
+**Returns:** Key files for the domain with their dependent counts and purposes.
+
+---
+
+### validate_expertise
+
+Validate that key_files defined in expertise.yaml exist in the indexed codebase. Checks for stale or missing file references.
+
+**Parameters:**
+- `domain` (required): Domain name to validate (e.g., `database`, `api`, `indexer`)
+
+**Example:**
+```json
+{
+  "domain": "api"
+}
+```
+
+**Returns:** Validation results including valid patterns, stale patterns with reasons, missing key files, and summary statistics.
+
+---
+
+### sync_expertise
+
+Sync patterns from expertise.yaml files to the patterns table. Extracts pattern definitions and stores them for future reference.
+
+**Parameters:**
+- `domain` (optional): Specific domain to sync. If not provided, syncs all domains
+- `force` (optional): Force sync even if patterns already exist (default: false)
+
+**Example:**
+```json
+{
+  "domain": "database",
+  "force": false
+}
+```
+
+**Returns:** Sync results including patterns synced, patterns skipped, and list of synced pattern names.
+
+---
+
+### get_recent_patterns
+
+Get recently observed patterns from the patterns table. Useful for understanding codebase conventions.
+
+**Parameters:**
+- `domain` (optional): Filter patterns by domain
+- `days` (optional): Only return patterns from the last N days (default: 30)
+- `limit` (optional): Maximum number of patterns to return (default: 20)
+- `repository` (optional): Filter to a specific repository ID
+
+**Example:**
+```json
+{
+  "domain": "api",
+  "days": 7,
+  "limit": 10
+}
+```
+
+**Returns:** Recent patterns including pattern type, file path, description, example, and creation timestamp.
 
 ---
 

--- a/web/docs/content/installation.md
+++ b/web/docs/content/installation.md
@@ -2,8 +2,8 @@
 title: Installation
 description: Get KotaDB running locally
 order: 1
-last_updated: 2026-01-30
-version: 2.0.0
+last_updated: 2026-02-03
+version: 2.0.1
 reviewed_by: documentation-build-agent
 ---
 
@@ -41,6 +41,8 @@ kotadb --version
 
 You should see the version number printed to your terminal.
 
+> **Note**: KotaDB CLI outputs structured data to stdout and logs to stderr, making it suitable for piping and scripting.
+
 ## First Steps
 
 1. **Index a repository** - Point KotaDB at your codebase:
@@ -63,6 +65,8 @@ kotadb serve
 curl http://localhost:3000/health
 # Default port is 3000, configurable via PORT environment variable
 ```
+
+On first use, KotaDB automatically runs database migrations, including tables for the memory layer (decisions, failures, and patterns tracking).
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

- Update all user-facing documentation to align with current codebase before develop → main promotion
- Add documentation for **11 new MCP tools** (Memory Layer + Dynamic Expertise)
- Add 3 new architecture sections documenting major components added since v2.0.0

## Changes

| File | Changes |
|------|---------|
| `api-reference.md` | +270 lines - Added 11 new MCP tools with full parameter docs |
| `architecture.md` | +182 lines - Added Memory Layer, Expertise Layer, Context Seeding |
| `configuration.md` | +108 lines - Added versioning metadata, new config sections |
| `installation.md` | +8 lines - Version bump, CLI output note, migration note |

## New MCP Tools Documented

**Memory Layer Tools:**
- `generate_task_context` - Hook-based context injection
- `search_decisions` / `record_decision` - Architectural decisions
- `search_failures` / `record_failure` - Failed approaches
- `search_patterns` / `record_insight` - Patterns and insights

**Dynamic Expertise Tools:**
- `get_domain_key_files` - Domain key file discovery
- `validate_expertise` - Expertise validation
- `sync_expertise` - Pattern synchronization
- `get_recent_patterns` - Recent patterns retrieval

## Test plan

- [x] Documentation builds without errors
- [x] All 19 MCP tools now documented (was 8)
- [x] Version updated to 2.0.1 in all frontmatter
- [x] Dates updated to 2026-02-03

🤖 Generated with [Claude Code](https://claude.com/claude-code)