### PR TITLE
fix(website): resolve docs/blog rendering issues #132

### DIFF
--- a/web/blog/index.html
+++ b/web/blog/index.html
@@ -206,7 +206,7 @@
       container.innerHTML = posts.map(function(post) {
         var dateHtml = post.date ? '<div class="blog-post-date">' + formatDate(post.date) + '</div>' : '';
         var descHtml = post.description ? '<p class="blog-post-description">' + escapeHtml(post.description) + '</p>' : '';
-        return '<article class="blog-post-card"><a href="post.html?slug=' + encodeURIComponent(post.slug) + '"><h2>' + escapeHtml(post.title) + '</h2>' + dateHtml + descHtml + '</a></article>';
+        return '<article class="blog-post-card"><a href="post.html#' + encodeURIComponent(post.slug) + '"><h2>' + escapeHtml(post.title) + '</h2>' + dateHtml + descHtml + '</a></article>';
       }).join('');
     }
     

--- a/web/blog/post.html
+++ b/web/blog/post.html
@@ -30,6 +30,7 @@
     .blog-post-content {
       padding: var(--space-2xl) 0;
       max-width: 48rem;
+      margin: 0 auto;
     }
     
     .blog-post-content h1,
@@ -94,6 +95,27 @@
     .error-message p {
       color: var(--color-text-muted);
       margin-bottom: var(--space-lg);
+    }
+
+    /* Hide heading anchors by default, show on hover */
+    .blog-post-content .heading-anchor {
+      color: var(--color-text-muted);
+      text-decoration: none;
+      margin-right: var(--space-sm);
+      opacity: 0;
+      transition: opacity var(--transition-fast);
+    }
+
+    .blog-post-content h1:hover .heading-anchor,
+    .blog-post-content h2:hover .heading-anchor,
+    .blog-post-content h3:hover .heading-anchor,
+    .blog-post-content h4:hover .heading-anchor {
+      opacity: 1;
+    }
+
+    /* Hide duplicate H1 since title is in header */
+    #post-content > h1:first-child {
+      display: none;
     }
   </style>
 </head>
@@ -177,8 +199,8 @@
     }
     
     function getSlugFromUrl() {
-      const params = new URLSearchParams(window.location.search);
-      return params.get('slug');
+      // Support both hash and query param for slug
+      const hash = window.location.hash.slice(1); if (hash) return decodeURIComponent(hash); const params = new URLSearchParams(window.location.search); return params.get('slug');
     }
     
     function showError(message) {


### PR DESCRIPTION
## Summary

- Fix marked.js renderer to handle new token object format (was causing `text.toLowerCase is not a function` errors)
- Hide heading anchor `#` symbols by default, show on hover
- Hide duplicate H1 in blog posts (title already shown in header)
- Center blog post content properly
- Use hash-based URLs for blog posts (fixes `npx serve` compatibility)

## Test plan

- [x] Docs page loads all sections (Installation, Configuration, API Reference, Architecture)
- [x] Blog index shows posts correctly
- [x] Blog posts render with proper formatting
- [x] No duplicate titles on blog posts
- [x] Anchor symbols hidden until hover
- [x] Works with both `python -m http.server` and `npx serve`

Fixes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)