### PR TITLE
feat(marketing): add lead magnet CTAs to README and website

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,20 @@ KotaDB uses stdio (standard input/output) instead of HTTP ports:
 
 ---
 
+## Learn to Build AI Dev Tools
+
+KotaDB is part of my journey building AI-powered developer tools. I share everything I learn:
+
+🎥 **YouTube** - Tutorials on Claude Code, MCP, and building tools like this  
+→ [youtube.com/@jaymin-west](https://youtube.com/@jaymin-west)
+
+👥 **Prompt to Prod Community** - Learn to ship AI apps, not just prompt  
+→ [skool.com/prompt-to-prod](https://skool.com/prompt-to-prod)
+
+Built by [Jaymin West](https://jayminwest.com)
+
+---
+
 ## For Contributors
 
 ### Development Setup

--- a/web/css/main.css
+++ b/web/css/main.css
@@ -599,6 +599,71 @@ pre code {
   transform: translateY(0);
 }
 
+
+/* ===== Creator Section ===== */
+.creator {
+  padding: var(--space-4xl) 0;
+  background: var(--color-bg-alt);
+}
+
+.creator-content {
+  text-align: center;
+}
+
+.creator-content h2 {
+  margin-bottom: var(--space-sm);
+}
+
+.creator-content > p {
+  color: var(--color-text-muted);
+  max-width: 32rem;
+  margin: 0 auto var(--space-xl);
+}
+
+.creator-ctas {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: var(--space-lg);
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.cta-card {
+  display: block;
+  padding: var(--space-xl);
+  background: var(--glass-bg);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--border-radius-lg);
+  text-decoration: none;
+  transition: all var(--transition-base);
+}
+
+.cta-card:hover {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: var(--color-primary);
+  transform: translateY(-2px);
+  box-shadow: 0 10px 40px -20px rgba(34, 211, 238, 0.2);
+}
+
+.cta-icon {
+  font-size: 2rem;
+  margin-bottom: var(--space-md);
+}
+
+.cta-card h3 {
+  font-size: var(--font-size-lg);
+  color: var(--color-text);
+  margin-bottom: var(--space-sm);
+}
+
+.cta-card p {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  margin-bottom: 0;
+  line-height: 1.6;
+}
 /* ===== Responsive ===== */
 @media (max-width: 768px) {
   :root { 
@@ -630,6 +695,14 @@ pre code {
     padding: var(--space-md);
   }
   
+  
+  .creator {
+    padding: var(--space-3xl) 0;
+  }
+  
+  .creator-ctas {
+    grid-template-columns: 1fr;
+  }
   .footer-content { 
     flex-direction: column; 
     text-align: center; 

--- a/web/index.html
+++ b/web/index.html
@@ -138,6 +138,29 @@
       </div>
     </section>
 
+    <section class="creator">
+      <div class="container">
+        <div class="creator-content fade-in">
+          <h2>Built by Jaymin West</h2>
+          <p>I'm building AI dev tools and teaching others to do the same. Join me on the journey:</p>
+          
+          <div class="creator-ctas">
+            <a href="https://youtube.com/@jaymin-west" class="cta-card" target="_blank" rel="noopener noreferrer">
+              <div class="cta-icon">🎥</div>
+              <h3>YouTube</h3>
+              <p>Tutorials on Claude Code, MCP, and building AI tools</p>
+            </a>
+            
+            <a href="https://skool.com/prompt-to-prod" class="cta-card" target="_blank" rel="noopener noreferrer">
+              <div class="cta-icon">👥</div>
+              <h3>Prompt to Prod</h3>
+              <p>Learn to ship AI apps, not just prompt</p>
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+
     <section class="quickstart">
       <div class="container">
         <h2 class="fade-in">Quick Start</h2>
@@ -158,7 +181,7 @@ kotadb serve</code></pre>
   <footer class="site-footer">
     <div class="container">
       <div class="footer-content">
-        <p>2026 kotadb. Released under the <a href="https://github.com/jayminwest/kotadb/blob/main/LICENSE">MIT License</a>.</p>
+        <p>Built by <a href="https://jayminwest.com" target="_blank" rel="noopener noreferrer">Jaymin West</a> • <a href="https://youtube.com/@jaymin-west" target="_blank" rel="noopener noreferrer">YouTube</a> • <a href="https://skool.com/prompt-to-prod" target="_blank" rel="noopener noreferrer">Community</a></p>
         <nav class="footer-nav">
           <a href="https://github.com/jayminwest/kotadb" target="_blank" rel="noopener noreferrer">GitHub</a>
           <a href="https://github.com/jayminwest/kotadb/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">License</a>


### PR DESCRIPTION
## Summary

- Add "Learn to Build AI Dev Tools" section to README with YouTube and Skool community links
- Add creator section to website (after features) with glass morphism CTA cards
- Update website footer with Jaymin West attribution and social links
- GitHub topics (claude-code, mcp, ai-tools) added via CLI

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Preview website locally (`cd web && python -m http.server`)
- [ ] Check creator section styling matches liquid glass design
- [ ] Confirm footer links work
- [ ] Verify GitHub topics appear on repo page

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)