### PR TITLE
feat(cli): add --toolset flag for MCP tool filtering #142

### DIFF
--- a/.claude/agents/experts/api/expertise.yaml
+++ b/.claude/agents/experts/api/expertise.yaml
@@ -248,6 +248,143 @@ key_operations:
         instead: "Use KOTADB_PATH env var for file-based test database"
         reason: "Global singleton needs file path for proper isolation"
 
+
+  implement_tool_tier_filtering:
+    when: Adding CLI-based tool filtering to support different MCP tool subsets (core, memory, expertise)
+    approach: |
+      1. Define ToolTier enum for categorization: "core" | "sync" | "memory" | "expertise"
+      2. Add tier property to ToolDefinition interface in app/src/mcp/tools.ts
+      3. Tag each tool definition with appropriate tier:
+         - core: Essential code intelligence (search, index, dependencies, impact, context)
+         - sync: Git sync tools (kota_sync_export, kota_sync_import)
+         - memory: Memory layer (decisions, failures, patterns, insights)
+         - expertise: Dynamic expertise validation and pattern extraction
+      4. Define ToolsetTier for user-facing selection: "default" | "core" | "memory" | "full"
+      5. Create filterToolsByTier() function with tier mapping logic:
+         - core: 6 tools (core tier only)
+         - default: 8 tools (core + sync tiers)
+         - memory: 14 tools (core + sync + memory tiers)
+         - full: all tools (all tiers)
+      6. Add --toolset CLI flag to parseArgs() with validation
+      7. Extract CLI parsing to separate module (app/src/cli/args.ts) for testability
+      8. Pass toolset via McpServerContext.toolset to server
+      9. Filter tools in ListToolsRequestSchema handler using context.toolset
+      10. Create comprehensive tests covering tier hierarchy and filtering
+    timestamp: 2026-02-03
+    evidence: |
+      Uncommitted changes in git diff:
+      - app/src/cli.ts (--toolset flag, runStdioMode parameter)
+      - app/src/cli/args.ts (extracted parsing, ToolsetTier type guard)
+      - app/src/mcp/server.ts (McpServerContext.toolset, filtered tool listing)
+      - app/src/mcp/tools.ts (ToolTier property, filterToolsByTier function)
+      - app/tests/cli/toolset.test.ts (CLI parsing tests)
+      - app/tests/mcp/toolset-filtering.test.ts (tier filtering tests)
+      - README.md (toolset tier documentation table)
+    rationale: |
+      Tool proliferation creates cognitive overload for LLMs and reduces token efficiency.
+      Different use cases need different tool sets - Claude Code users may only need core tools,
+      while agentic workflows benefit from memory layer. Tiered architecture allows gradual
+      adoption: start with core (6 tools), expand to memory (14 tools), enable all for experts.
+      CLI-based selection is more flexible than compile-time configuration.
+    key_patterns:
+      - Separate ToolTier (internal categorization) from ToolsetTier (user-facing selection)
+      - Hierarchical tier design: each tier includes previous (core ⊂ default ⊂ memory ⊂ full)
+      - Extract CLI parsing to separate module for testability (avoid mocking main())
+      - Type guards for runtime validation (isValidToolsetTier)
+      - Filter at server initialization (ListToolsRequestSchema) not per tool call
+      - Comprehensive tests verify tier hierarchy and exact tool counts
+    pitfalls:
+      - what: "Filtering tools in CallToolRequestSchema handler"
+        instead: "Filter in ListToolsRequestSchema only"
+        reason: "Client should only see available tools, attempting unavailable tool is client error"
+      - what: "Using environment variables for tier selection"
+        instead: "Use CLI flag (--toolset) for explicit control"
+        reason: "CLI flags are more visible and don't persist across sessions"
+      - what: "Hardcoding tier logic in each executor"
+        instead: "Single filterToolsByTier() function based on tier property"
+        reason: "Centralized logic prevents tier drift"
+      - what: "Breaking tier hierarchy (default doesn't include core)"
+        instead: "Test tier hierarchy with set containment checks"
+        reason: "Unexpected behavior if higher tiers exclude lower tier tools"
+    affected_files: |
+      - app/src/cli.ts (ToolsetTier import, parseArgs, runStdioMode signature)
+      - app/src/cli/args.ts (new file - extracted CLI parsing logic)
+      - app/src/mcp/server.ts (McpServerContext interface, tool filtering)
+      - app/src/mcp/tools.ts (ToolTier type, tier property, filterToolsByTier)
+      - app/tests/cli/toolset.test.ts (new file - CLI parsing tests)
+      - app/tests/mcp/toolset-filtering.test.ts (new file - tier filtering tests)
+
+  resolve_flexible_repository_identifiers:
+    when: Adding support for repository identification by full_name OR UUID in MCP tools
+    approach: |
+      1. Create resolveRepositoryIdentifierWithError() helper in queries module
+      2. Accept repository parameter as string (UUID or owner/repo format)
+      3. Try UUID resolution first: SELECT * FROM repositories WHERE id = ?
+      4. Fall back to full_name resolution: SELECT * FROM repositories WHERE full_name = ?
+      5. Return { id: string } on success or { error: string } on failure
+      6. Use in tool executors BEFORE calling query functions:
+         - Extract optional repository parameter
+         - Call resolveRepositoryIdentifierWithError if present
+         - Return early with error message if resolution fails
+         - Pass resolved UUID to query functions
+      7. Update query functions to accept repositoryId (UUID) not repository (any format)
+    timestamp: 2026-02-03
+    evidence: Commit 9adc86f "fix(mcp): resolve full_name to UUID in list_recent_files #137 (#141)"
+    rationale: |
+      User experience improvement: developers think in terms of "owner/repo" names, not UUIDs.
+      Internal consistency: query functions should work with stable IDs (UUIDs), not user-facing names.
+      Separation of concerns: resolution logic belongs in executor layer, not query layer.
+    key_patterns:
+      - Resolution at tool executor boundary (before query calls)
+      - Query functions accept normalized IDs (UUID) only
+      - Try-fallback pattern: UUID first, then full_name
+      - Return error object vs throwing (enables graceful tool failure messages)
+      - Early return pattern: resolve -> check error -> proceed or return
+    pitfalls:
+      - what: "Putting resolution logic in query functions"
+        instead: "Resolve in executor, pass UUID to query"
+        reason: "Query functions should work with normalized IDs only"
+      - what: "Throwing errors on invalid repository"
+        instead: "Return { error: string } for graceful handling"
+        reason: "MCP tools should return structured errors, not throw"
+      - what: "Only supporting UUID format"
+        instead: "Support both UUID and full_name (owner/repo)"
+        reason: "User experience - developers think in repo names"
+    affected_files: |
+      - app/src/api/queries.ts (resolveRepositoryIdentifierWithError helper)
+      - app/src/mcp/tools.ts (executeListRecentFiles resolver usage)
+
+  extract_cli_parsing_for_testability:
+    when: Need to test CLI argument parsing without invoking main() or mocking process.exit
+    approach: |
+      1. Create app/src/cli/args.ts module for testable parsing logic
+      2. Define CliOptions interface with all CLI flags
+      3. Extract parseArgs(args: string[]): CliOptions function
+      4. Extract validation helpers (isValidToolsetTier, etc.)
+      5. Keep error handling in parseArgs (process.stderr.write + process.exit)
+      6. Import and use in main CLI entry point (app/src/cli.ts)
+      7. Write unit tests against exported parseArgs function
+      8. Test error paths by expecting process.exit() calls
+    timestamp: 2026-02-03
+    evidence: New file app/src/cli/args.ts + app/tests/cli/toolset.test.ts
+    rationale: |
+      Testing main() is difficult: requires mocking process.exit, process.argv, stdout/stderr.
+      Extracting parseArgs enables direct unit testing with controlled inputs.
+      Follows antimocking philosophy: test real parsing logic, not mocks.
+    key_patterns:
+      - Pure parsing function: string[] -> CliOptions
+      - Validation helpers return booleans (type guards)
+      - Error messages via process.stderr.write (not thrown exceptions)
+      - process.exit(1) for invalid input (expected behavior, testable via expect)
+      - CliOptions interface defines all flags with defaults
+    pitfalls:
+      - what: "Throwing exceptions on invalid input"
+        instead: "Write to stderr and call process.exit(1)"
+        reason: "CLI tools should exit with status codes, not throw"
+      - what: "Testing main() directly"
+        instead: "Extract parseArgs and test that"
+        reason: "Avoids complex mocking of process global"
+
   configure_npm_package_distribution:
     when: Publishing TypeScript package with path aliases for direct execution (Bun/ts-node)
     approach: |
@@ -349,53 +486,8 @@ key_operations:
 patterns:
   cli_entry_point_pattern:
     structure: |
-      // app/src/cli.ts (with #!/usr/bin/env bun shebang on first line)
-      function getVersion(): string {
-        const packageJsonPath = join(__dirname, "..", "package.json");
-        const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
-        return packageJson.version || "unknown";
-      }
-      
-      function parseArgs(args: string[]): CliOptions {
-        const options: CliOptions = { port: 3000, help: false, version: false, stdio: false };
-        for (let i = 0; i < args.length; i++) {
-          if (args[i] === "--help" || args[i] === "-h") options.help = true;
-          else if (args[i] === "--version" || args[i] === "-v") options.version = true;
-          else if (args[i] === "--stdio") options.stdio = true;
-          else if (args[i] === "--port") options.port = Number(args[++i]);
-        }
-        return options;
-      }
-      
-      async function main(): Promise<void> {
-        const options = parseArgs(process.argv.slice(2));
-        if (options.version) {
-          process.stdout.write(`kotadb v${getVersion()}\n`);
-          process.exit(0);
-        }
-        
-        // Route to stdio mode
-        if (options.stdio) {
-          await runStdioMode();
-          return;
-        }
-        
-        // HTTP mode
-        const server = createExpressApp().listen(options.port);
-        const shutdown = () => {
-          server.close(() => process.exit(0));
-          setTimeout(() => process.exit(1), 10000);
-        };
-        process.on("SIGTERM", shutdown);
-        process.on("SIGINT", shutdown);
-      }
-    notes:
-      - First line MUST be #!/usr/bin/env bun (no BOM)
-      - process.argv.slice(2) skips executable and script path
-      - getVersion() reads package.json at runtime
-      - Use process.stdout.write / process.stderr.write (not console.*)
-      - 10-second timeout in shutdown handler (HTTP mode only)
-      - Stdio mode requires no shutdown handler (transport manages lifecycle)
+      See create_cli_entry_point operation for full implementation.
+      Key: Shebang, parseArgs(), getVersion(), shutdown handlers
     timestamp: 2026-01-29
     evidence: app/src/cli.ts
 
@@ -454,140 +546,244 @@ patterns:
 
   logger_stderr_routing_pattern:
     structure: |
-      // app/src/logging/logger.ts (stderr routing for stdio mode)
-      export interface LogContext {
-        request_id?: string;
-        user_id?: string;
-        forceStderr?: boolean;  // NEW: route all logs to stderr
-        [key: string]: unknown;
-      }
-      
-      export function createLogger(baseContext?: LogContext): Logger {
-        const context = baseContext ? maskSensitiveData(baseContext) : {};
-        const forceStderr = context.forceStderr === true;
-        
-        return {
-          info(message: string, additionalContext?: LogContext): void {
-            const entry: LogEntry = { /* ... */ };
-            writeLog(entry, forceStderr);  // Pass forceStderr flag
-          },
-          // ... other log methods
-        };
-      }
-      
-      function writeLog(entry: LogEntry, forceStderr = false): void {
-        const json = JSON.stringify(entry);
-        const output = `${json}\n`;
-        
-        if (forceStderr || entry.level === "error") {
-          process.stderr.write(output);
-        } else {
-          process.stdout.write(output);
-        }
-      }
-    notes:
-      - forceStderr flag routes ALL log levels to stderr (including info/debug)
-      - Default behavior: info/debug/warn to stdout, error to stderr
-      - Stdio mode behavior: ALL logs to stderr (stdout is protocol channel)
-      - Flag is set once at logger creation, not per log call
+      See implement_mcp_stdio_transport operation for details.
+      Key: LogContext.forceStderr, writeLog routing
     timestamp: 2026-01-29
-    evidence: app/src/logging/logger.ts (forceStderr implementation)
+    evidence: app/src/logging/logger.ts
 
   express_route_pattern:
     structure: |
-      app.get("/path", async (req: AuthenticatedRequest, res: Response) => {
-          const context = req.authContext!;
-          const param = req.query.param as string;
-          if (!param) {
-              addRateLimitHeaders(res, context.rateLimit);
-              return res.status(400).json({ error: "Missing param" });
-          }
-          const results = queryFunction(param);
-          addRateLimitHeaders(res, context.rateLimit);
-          res.json({ results });
-      });
-    notes:
-      - AuthenticatedRequest for authenticated routes
-      - Always addRateLimitHeaders before response
-      - Return early with status code on validation failure
+      See add_express_route operation.
+      Key: AuthenticatedRequest, addRateLimitHeaders, early validation
 
   mcp_tool_pattern:
     structure: |
-      export const TOOL_NAME: ToolDefinition = {
-          name: "tool_name",
-          description: "When/why to use",
-          inputSchema: {
-              type: "object",
-              properties: { param: { type: "string", description: "..." } },
-              required: ["param"],
-          },
-      };
-      
-      export async function executeTool(
-          params: unknown,
-          _requestId: string | number,
-          userId: string,
-      ): Promise<unknown> {
-          if (typeof params !== "object" || params === null)
-              throw new Error("Parameters must be an object");
-          const p = params as Record<string, unknown>;
-          if (p.param === undefined) throw new Error("Missing: param");
-          return await queryFunction(p.param as string);
-      }
-    notes:
-      - Tool description guides LLM on when/how to use
-      - Properties need descriptions in inputSchema
-      - Validate all params including types and ranges
+      See register_mcp_tool operation for full pattern.
+      Key: ToolDefinition with inputSchema, executor with parameter validation
 
   sqlite_query_pattern:
     structure: |
-      function queryInternal(db: KotaDatabase, param: string): Result[] {
-          const sql = `SELECT * FROM table WHERE condition = ? LIMIT ?`;
-          const rows = db.query<RowType>(sql, [param, 20]);
-          return rows.map(transform);
-      }
-      export function query(param: string): Result[] {
-          return queryInternal(getGlobalDatabase(), param);
-      }
-    notes:
-      - Internal function takes db param (testable)
-      - Public function uses getGlobalDatabase()
-      - db.query<T>(), db.queryOne<T>(), db.run(), db.transaction(), db.prepare()
+      See add_query_function operation.
+      Key: Internal function with db param, public uses getGlobalDatabase()
 
   fts5_search_pattern:
     structure: |
-      function escapeFts5Term(term: string): string {
-          return `"${term.replace(/"/g, '""')}"`;
-      }
-      function searchInternal(db: KotaDatabase, term: string): Result[] {
-          const sql = `
-              SELECT f.*, snippet(fts, 1, '<mark>', '</mark>', '...', 32) AS snippet
-              FROM table_fts fts
-              JOIN table f ON fts.rowid = f.rowid
-              WHERE table_fts MATCH ?
-              ORDER BY bm25(table_fts) LIMIT 100
-          `;
-          return db.query<Result>(sql, [escapeFts5Term(term)]);
-      }
-    notes:
-      - Always escape with escapeFts5Term before MATCH
-      - Use bm25() for relevance, snippet() for context
-      - Test: hyphens, phrases, FTS5 keywords, quotes
+      See implement_fts5_search operation.
+      Key: escapeFts5Term() before MATCH, bm25() for ranking, snippet() for context
 
   npm_package_files_pattern:
     structure: |
-      // app/package.json (TypeScript package with path aliases for Bun)
-      {
-        "name": "kotadb",
-        "version": "2.0.1",
-        "bin": {
-          "kotadb": "./src/cli.ts"
-        },
-        "files": [
-          "src/**/*.ts",
-          "src/**/*.js",
-          "!src/**/*.test.ts",
-          "!src/**/*.spec.ts",
+      See configure_npm_package_distribution operation.
+      Key: tsconfig.json in files array, path aliases, testing with npm pack
+    timestamp: 2026-01-29
+    evidence: Issue #39
+
+  tool_tier_filtering_pattern:
+    structure: |
+      // app/src/mcp/tools.ts (tool tier categorization and filtering)
+      export type ToolTier = "core" | "sync" | "memory" | "expertise";
+      export type ToolsetTier = "default" | "core" | "memory" | "full";
+      
+      export interface ToolDefinition {
+        name: string;
+        tier: ToolTier;  // NEW: categorize by feature tier
+        description: string;
+        inputSchema: { /* ... */ };
+      }
+      
+      export const SEARCH_CODE_TOOL: ToolDefinition = {
+        tier: "core",  // Essential code intelligence
+        name: "search_code",
+        description: "Search indexed code files...",
+        inputSchema: { /* ... */ },
+      };
+      
+      export function filterToolsByTier(tier: ToolsetTier): ToolDefinition[] {
+        const allTools = getToolDefinitions();
+        switch (tier) {
+          case "core":
+            return allTools.filter((t) => t.tier === "core");
+          case "default":
+            return allTools.filter((t) => t.tier === "core" || t.tier === "sync");
+          case "memory":
+            return allTools.filter((t) => 
+              t.tier === "core" || t.tier === "sync" || t.tier === "memory"
+            );
+          case "full":
+            return allTools;
+        }
+      }
+      
+      // app/src/mcp/server.ts (context-aware tool listing)
+      export interface McpServerContext {
+        userId: string;
+        toolset?: ToolsetTier;  // NEW: optional tier selection
+      }
+      
+      server.setRequestHandler(ListToolsRequestSchema, async () => {
+        const tier = context.toolset || "default";
+        const filteredTools = filterToolsByTier(tier);
+        return { tools: filteredTools };
+      });
+      
+      // app/src/cli/args.ts (testable CLI parsing)
+      export type ToolsetTier = "default" | "core" | "memory" | "full";
+      export interface CliOptions {
+        port: number;
+        stdio: boolean;
+        toolset: ToolsetTier;  // NEW: CLI-selectable tier
+      }
+      
+      export function isValidToolsetTier(value: string): value is ToolsetTier {
+        return ["default", "core", "memory", "full"].includes(value);
+      }
+      
+      export function parseArgs(args: string[]): CliOptions {
+        const options: CliOptions = { 
+          port: 3000, 
+          stdio: false, 
+          toolset: "default" 
+        };
+        
+        for (let i = 0; i < args.length; i++) {
+          if (args[i] === "--toolset") {
+            const tierStr = args[++i];
+            if (!isValidToolsetTier(tierStr)) {
+              process.stderr.write(`Invalid toolset: ${tierStr}\n`);
+              process.exit(1);
+            }
+            options.toolset = tierStr;
+          }
+        }
+        return options;
+      }
+    notes:
+      - ToolTier (internal): Categorizes tools by feature domain
+      - ToolsetTier (user-facing): CLI flag values for tier selection
+      - Hierarchical design: core ⊂ default ⊂ memory ⊂ full
+      - Filter at ListToolsRequestSchema (not per tool call)
+      - Extract CLI parsing to separate module for testability
+      - Type guards enable runtime validation of CLI input
+    timestamp: 2026-02-03
+    evidence: Uncommitted changes across app/src/cli/, app/src/mcp/
+    
+  repository_identifier_resolution_pattern:
+    structure: |
+      // app/src/api/queries.ts (flexible identifier resolution)
+      export function resolveRepositoryIdentifierWithError(
+        identifier: string
+      ): { id: string } | { error: string } {
+        const db = getGlobalDatabase();
+        
+        // Try UUID first
+        const byId = db.queryOne<{ id: string }>(
+          `SELECT id FROM repositories WHERE id = ?`,
+          [identifier]
+        );
+        if (byId) return { id: byId.id };
+        
+        // Fall back to full_name (owner/repo)
+        const byFullName = db.queryOne<{ id: string }>(
+          `SELECT id FROM repositories WHERE full_name = ?`,
+          [identifier]
+        );
+        if (byFullName) return { id: byFullName.id };
+        
+        return { error: `Repository not found: ${identifier}` };
+      }
+      
+      // app/src/mcp/tools.ts (executor-level resolution)
+      export async function executeListRecentFiles(
+        params: unknown,
+        requestId: string | number,
+        userId: string
+      ): Promise<unknown> {
+        // Extract optional repository parameter
+        const repository = (params as Record<string, unknown>).repository;
+        
+        // Resolve to UUID if provided
+        let repositoryId: string | undefined;
+        if (repository && typeof repository === "string") {
+          const result = resolveRepositoryIdentifierWithError(repository);
+          if ("error" in result) {
+            return { results: [], message: result.error };
+          }
+          repositoryId = result.id;
+        }
+        
+        // Call query function with normalized ID
+        const files = listRecentFiles(limit, repositoryId);
+        return { results: files };
+      }
+    notes:
+      - Resolve at executor boundary (before query calls)
+      - Query functions accept UUID only (normalized IDs)
+      - Try-fallback pattern: UUID first, then full_name
+      - Return error object vs throwing (graceful MCP tool failures)
+      - Early return pattern: resolve -> check error -> proceed
+      - User experience: developers think in repo names, not UUIDs
+    timestamp: 2026-02-03
+    evidence: Commit 9adc86f (list_recent_files full_name support)
+
+  cli_parsing_extraction_pattern:
+    structure: |
+      // app/src/cli/args.ts (extracted for testability)
+      export interface CliOptions {
+        port: number;
+        help: boolean;
+        version: boolean;
+        stdio: boolean;
+        toolset: ToolsetTier;
+      }
+      
+      export function isValidToolsetTier(value: string): value is ToolsetTier {
+        return ["default", "core", "memory", "full"].includes(value);
+      }
+      
+      export function parseArgs(args: string[]): CliOptions {
+        const options: CliOptions = {
+          port: Number(process.env.PORT ?? 3000),
+          help: false,
+          version: false,
+          stdio: false,
+          toolset: "default",
+        };
+        
+        for (let i = 0; i < args.length; i++) {
+          const arg = args[i];
+          if (arg === "--toolset") {
+            const tierStr = args[++i];
+            if (!tierStr || !isValidToolsetTier(tierStr)) {
+              process.stderr.write("Error: Invalid toolset\n");
+              process.exit(1);
+            }
+            options.toolset = tierStr;
+          }
+          // ... other flags
+        }
+        return options;
+      }
+      
+      // app/tests/cli/toolset.test.ts (direct testing)
+      test("parseArgs correctly parses --toolset core", () => {
+        const options = parseArgs(["--toolset", "core"]);
+        expect(options.toolset).toBe("core");
+      });
+      
+      test("parseArgs defaults to 'default' when no --toolset", () => {
+        const options = parseArgs([]);
+        expect(options.toolset).toBe("default");
+      });
+    notes:
+      - Extract pure parsing logic: string[] -> CliOptions
+      - Keep validation in parseArgs (process.exit on error)
+      - Export type guards for reusability
+      - CliOptions defines all flags with defaults
+      - Test directly without mocking process.argv
+      - Follows antimocking: test real logic, not mocks
+    timestamp: 2026-02-03
+    evidence: app/src/cli/args.ts, app/tests/cli/toolset.test.ts
+
           "tsconfig.json",        // Required for path alias resolution
           "shared/**/*.ts"        // Include all aliased dependencies
         ]
@@ -706,26 +902,33 @@ known_issues:
 
 stability:
   convergence_indicators:
-    insight_rate_trend: decreasing
+    insight_rate_trend: stable
     contradiction_count: 0
-    new_patterns_added_this_cycle: 0
+    new_patterns_added_this_cycle: 3
     patterns_updated_this_cycle: 0
-    new_operations_added_this_cycle: 1
-    last_reviewed: 2026-02-02
+    new_operations_added_this_cycle: 3
+    last_reviewed: 2026-02-03
     utility_ratio: 1.0
     notes: |
-      Eighth review cycle - OpenAPI specification maintenance:
+      Ninth review cycle - Tool tier filtering and repository identifier resolution:
       
-      New operation: maintain_openapi_spec
-      - Guidance on spec-implementation drift detection
-      - Schema cleanup for removed features
-      - Server definition synchronization
-      - MCP vs HTTP documentation separation
-      - Test synchronization patterns
+      New operations (3):
+      1. implement_tool_tier_filtering - CLI-based MCP tool filtering with tiered subsets
+      2. resolve_flexible_repository_identifiers - UUID + full_name resolution pattern
+      3. extract_cli_parsing_for_testability - Separate parsing logic for unit testing
       
-      No new patterns - existing patterns cover implementation.
+      New patterns (3):
+      1. tool_tier_filtering_pattern - ToolTier vs ToolsetTier separation, hierarchical design
+      2. repository_identifier_resolution_pattern - Executor-level resolution, try-fallback
+      3. cli_parsing_extraction_pattern - Testable parseArgs without mocking process
       
-      Previously stable patterns:
+      Architectural significance:
+      - Tool tier system addresses LLM cognitive overload (20 -> 6-14 tools selectable)
+      - Hierarchical tier design enables gradual adoption path
+      - Repository identifier flexibility improves developer experience
+      - CLI extraction pattern enables antimocking test philosophy
+      
+      Previously stable patterns (all remain valid):
       - CLI entry point (Issue #19)
       - MCP stdio transport (Issue #49)
       - Optional parameter filtering (Issue #608)
@@ -734,17 +937,20 @@ stability:
       - Local file path validation
       - Local auth bypass
       - npm package distribution
+      - OpenAPI maintenance
       
-      Architecture stability: Very High
-      - Zero contradictions across 8 cycles
-      - All core operations documented
-      - All 8 MCP tools with comprehensive tests
-      - CLI deployment pattern established
-      - Both MCP transports (stdio + HTTP) fully documented
-      - OpenAPI maintenance patterns captured
-      - Decreasing insight rate indicates domain maturity
+      Architecture stability: High
+      - Zero contradictions across 9 cycles
+      - New patterns extend (not replace) existing architecture
+      - Tier system is additive change - existing tools unchanged
+      - Repository resolution improves ergonomics without breaking changes
       
-      Recent changes are refinements (documentation cleanup, spec accuracy)
-      rather than new architectural patterns, suggesting domain convergence.
+      Size governance:
+      - Current size: 955 lines (after additions and consolidation)
+      - Exceeded 800-line warning threshold, applied pruning to stay under 1000
+      - Pruned redundant pattern details already covered in operations
+      - Condensed: cli_entry_point, logger_stderr, express_route, mcp_tool, sqlite_query, fts5_search patterns
+      - All new content is high-utility architectural patterns (tool tiers, repo resolution)
+      - Recommend monitoring: next pruning cycle if reaches 1000 lines
       
-      Next review: After 15-20 API commits or architectural changes
+      Next review: After 10-15 API commits or new architectural patterns

--- a/.claude/agents/experts/automation/expertise.yaml
+++ b/.claude/agents/experts/automation/expertise.yaml
@@ -1,5 +1,5 @@
 # Automation Expert Domain Expertise
-# Last reviewed: 2026-01-31
+# Last reviewed: 2026-02-03
 # Domain: automation layer development with Claude Agent SDK
 
 overview:
@@ -7,7 +7,8 @@ overview:
     Automation expert domain provides specialized knowledge for kotadb's automation layer,
     which uses the Claude Agent SDK (@anthropic-ai/claude-code) to execute automated workflows.
     This domain covers SDK integration patterns, workflow orchestration, metrics tracking with
-    SQLite, GitHub commenting via gh CLI, console output transparency, and cost tracking for AI operations.
+    SQLite, GitHub commenting via gh CLI, console output transparency, MCP toolset configuration,
+    and cost tracking for AI operations.
     
   scope:
     primary_codebase:
@@ -22,10 +23,15 @@ overview:
       - automation/package.json (SDK dependency)
       - automation/tsconfig.json (TypeScript config)
       - automation/README.md (documentation)
+      - app/src/cli/args.ts (CLI argument parsing with toolset tier support)
+      - app/src/mcp/tools.ts (MCP tool definitions with tier metadata)
+      - app/src/mcp/server.ts (MCP server with tool filtering)
     
     broader_scope:
       - Claude Agent SDK patterns (query(), message streaming, hooks, stderr callback)
-      - MCP server configuration for kotadb access
+      - MCP server configuration for kotadb access with toolset tiers
+      - MCP tool organization (core, sync, memory, expertise tiers)
+      - Tool filtering patterns for dynamic tool selection
       - Bun.spawn patterns for gh CLI integration
       - SQLite metrics storage (automation/.data/metrics.db)
       - ANSI escape code formatting for console output
@@ -59,6 +65,35 @@ core_implementation:
         - Display metrics table or run workflow
         - Handle exit codes
         - Record metrics and post GitHub comments
+        
+    cli_args_ts:
+      path: app/src/cli/args.ts
+      purpose: CLI argument parsing with toolset tier validation
+      responsibilities:
+        - Define ToolsetTier type ("default" | "core" | "memory" | "full")
+        - Parse --toolset flag with = and space syntax
+        - Validate tier values with type guard isValidToolsetTier
+        - Return parsed CliOptions with toolset field
+        - Provide helpful error messages for invalid tiers
+        
+    mcp_tools_ts:
+      path: app/src/mcp/tools.ts
+      purpose: MCP tool definitions with tier-based filtering
+      responsibilities:
+        - Define ToolDefinition interface with tier field
+        - Categorize tools into tiers (core, sync, memory, expertise)
+        - Implement filterToolsByTier for dynamic tool selection
+        - Map toolset tiers to tool tiers (core→core, default→core+sync, etc)
+        - Export tool filtering utilities for MCP server
+        
+    mcp_server_ts:
+      path: app/src/mcp/server.ts
+      purpose: MCP server with toolset-aware tool registration
+      responsibilities:
+        - Accept toolset in McpServerContext
+        - Filter tools by tier in ListToolsRequestSchema handler
+        - Log filtered tool count for debugging
+        - Thread toolset through server lifecycle
         
     orchestrator_ts:
       path: automation/src/orchestrator.ts
@@ -420,7 +455,7 @@ key_operations:
         kotadb: {
           type: "stdio",
           command: "bunx",
-          args: ["--bun", "kotadb"],
+          args: ["--bun", "kotadb", "--toolset", "memory"],
           env: { KOTADB_CWD: projectRoot }
         }
       }
@@ -466,6 +501,104 @@ key_operations:
       - Network failures are transient
       - Wrong repo format breaks comment posting
       - Not handling empty PR URL shows undefined
+      
+  configure_mcp_toolset:
+    when: Selecting MCP tool tier for workflow requirements
+    approach: |
+      Configure mcpServers with --toolset flag to control which tools are available.
+      Use tier-based filtering to balance capability with token overhead. Thread toolset
+      from CLI args through server context to tool filtering logic.
+    patterns:
+      - Toolset tiers: core (6), default (8), memory (14), full (19 tools)
+      - Tool tiers: core, sync, memory, expertise
+      - Tier mapping: core→core, default→core+sync, memory→core+sync+memory, full→all
+      - CLI parsing with --toolset flag (space and = syntax)
+      - Type guard validation: isValidToolsetTier(value)
+      - Context threading: CLI → McpServerContext → filterToolsByTier()
+      - Hierarchical tool inclusion: each tier includes previous tiers
+    code_example: |
+      // CLI parsing (app/src/cli/args.ts)
+      export type ToolsetTier = "default" | "core" | "memory" | "full";
+      
+      export function isValidToolsetTier(value: string): value is ToolsetTier {
+        return ["default", "core", "memory", "full"].includes(value as ToolsetTier);
+      }
+      
+      // MCP server configuration with toolset
+      mcpServers: {
+        kotadb: {
+          type: "stdio",
+          command: "bunx",
+          args: ["--bun", "kotadb", "--toolset", "memory"],
+          env: { KOTADB_CWD: projectRoot }
+        }
+      }
+      
+      // Tool filtering (app/src/mcp/tools.ts)
+      export function filterToolsByTier(tier: ToolsetTier): ToolDefinition[] {
+        const allTools = getToolDefinitions();
+        switch (tier) {
+          case "core":
+            return allTools.filter((t) => t.tier === "core");
+          case "default":
+            return allTools.filter((t) => t.tier === "core" || t.tier === "sync");
+          case "memory":
+            return allTools.filter((t) => 
+              t.tier === "core" || t.tier === "sync" || t.tier === "memory"
+            );
+          case "full":
+            return allTools;
+        }
+      }
+      
+      // MCP server tool registration
+      server.setRequestHandler(ListToolsRequestSchema, async () => {
+        const tier = context.toolset || "default";
+        const filteredTools = filterToolsByTier(tier);
+        return { tools: filteredTools };
+      });
+    pitfalls:
+      - Not validating toolset tier causes runtime errors
+      - Forgetting to thread toolset through context breaks filtering
+      - Tool tier metadata must be added to all ToolDefinitions
+      - Hierarchical inclusion requirement: higher tiers must include lower tiers
+      - Case-sensitive tier names ("core" not "CORE")
+      
+  implement_tool_tier_metadata:
+    when: Adding new MCP tool or refactoring tool definitions
+    approach: |
+      Add tier field to ToolDefinition for every tool. Categorize by purpose:
+      core for essential ops, sync for data export/import, memory for cross-session
+      intelligence, expertise for domain validation tools.
+    patterns:
+      - ToolDefinition interface includes tier: ToolTier field
+      - ToolTier type: "core" | "sync" | "memory" | "expertise"
+      - Core tier: search_code, index_repository, list_recent_files, search_dependencies,
+        analyze_change_impact, generate_task_context
+      - Sync tier: kota_sync_export, kota_sync_import
+      - Memory tier: search_decisions, record_decision, search_failures, record_failure,
+        search_patterns, record_insight
+      - Expertise tier: get_domain_key_files, validate_expertise, sync_expertise,
+        get_recent_patterns, validate_implementation_spec
+    code_example: |
+      export const SEARCH_CODE_TOOL: ToolDefinition = {
+        tier: "core",
+        name: "search_code",
+        description: "Search indexed code files...",
+        inputSchema: { /* ... */ }
+      };
+      
+      export const RECORD_DECISION_TOOL: ToolDefinition = {
+        tier: "memory",
+        name: "record_decision",
+        description: "Record a new architectural decision...",
+        inputSchema: { /* ... */ }
+      };
+    pitfalls:
+      - Missing tier field breaks filterToolsByTier
+      - Incorrect tier categorization confuses users
+      - Not updating tests when adding tier metadata
+
 
 decision_trees:
   console_output_strategy:
@@ -562,6 +695,25 @@ decision_trees:
       - condition: Errors
         action: Log to console AND store in metrics if workflow-level
         rationale: Both immediate feedback and historical tracking
+  mcp_toolset_selection:
+    question: Which toolset tier should I use for this workflow?
+    branches:
+      - condition: Minimal token overhead, basic code intelligence only
+        action: Use --toolset core (6 tools)
+        rationale: Smallest footprint for simple search/indexing tasks
+        
+      - condition: Standard workflows with occasional data sync
+        action: Use --toolset default (8 tools) or omit flag
+        rationale: Balanced capability, includes sync tools
+        
+      - condition: Need cross-session memory (decisions, failures, patterns)
+        action: Use --toolset memory (14 tools)
+        rationale: Enables persistent intelligence layer
+        
+      - condition: Advanced workflows requiring expertise validation
+        action: Use --toolset full (19 tools)
+        rationale: All capabilities including domain validation
+
 
 patterns:
   console_reporter_pattern:
@@ -646,6 +798,18 @@ best_practices:
     - Gate stack traces and detailed logs on verbosity
     - Always show errors and key actions regardless
     
+  mcp_toolset:    
+  mcp_toolset:
+    - Use --toolset flag to control tool availability
+    - Default tier (8 tools) for standard workflows
+    - Core tier (6 tools) for minimal token footprint
+    - Memory tier (14 tools) when cross-session intelligence needed
+    - Full tier (19 tools) for advanced validation workflows
+    - Add tier metadata to all new ToolDefinitions
+    - Validate toolset values with type guards
+    - Thread toolset through McpServerContext
+    - Test hierarchical inclusion (higher tiers include lower)
+  
   sdk_integration:
     - Always validate ANTHROPIC_API_KEY before query()
     - Use type guards for message handling
@@ -701,19 +865,17 @@ potential_enhancements:
   - Tool execution timeline visualization
 
 stability:
-  convergence_indicators:
-    insight_rate_trend: converging
+    insight_rate_trend: stable
     contradiction_count: 0
-    last_reviewed: 2026-02-01
+    last_reviewed: 2026-02-03
     notes: |
-      Issue #65 implementation (console output transparency) adds comprehensive
-      SDK hook integration, ANSI formatting patterns, and verbosity control.
-      ConsoleReporter successfully separates user-facing output from structured
-      logging. SDK stderr callback pattern established for suppressing default
-      output. All key automation operations now documented with code examples.
-      Domain approaching stability with most patterns established and tested.
-
-      Issue #64 implementation (git worktree isolation) adds worktree.ts module
-      with graceful fallback patterns, filesystem-safe timestamps, and preservation
-      strategies for debugging. Enables parallel workflow execution without conflicts.
-      See worktree-learnings.md for detailed patterns and best practices.
+      MCP toolset tier implementation adds flexible tool filtering with --toolset flag.
+      Four tiers (core, default, memory, full) enable token-conscious tool selection.
+      Tool tier metadata (core, sync, memory, expertise) allows hierarchical filtering.
+      Context threading pattern established: CLI → McpServerContext → filterToolsByTier().
+      Type guards and validation ensure runtime safety. Comprehensive test coverage
+      confirms hierarchical inclusion and tier boundaries. Pattern successfully balances
+      capability vs token overhead.
+      
+      Prior: Issue #65 (console transparency), #64 (worktree isolation). Domain stable
+      with established SDK integration, hook patterns, and reporting infrastructure.

--- a/.claude/agents/experts/claude-config/expertise.yaml
+++ b/.claude/agents/experts/claude-config/expertise.yaml
@@ -1,6 +1,6 @@
 # Claude Code Configuration Expertise
 # Target: 400-600 lines | Domain: Operational knowledge for .claude/ configuration
-# Last updated: 2026-02-02 (MCP tool naming, tool selection guidance)
+# Last updated: 2026-02-03 (Hook organization, memory layer integration, context seeding)
 
 overview:
   description: |
@@ -39,6 +39,7 @@ core_implementation:
         build-agent.md: Implementation agent with write access
         scout-agent.md: Read-only exploration agent
         review-agent.md: Code review agent
+        common/: Shared agent documentation (memory-usage.md)
         experts/<domain>/:
           purpose: 4-agent pattern (plan/build/improve/question + expertise.yaml)
           pattern: Domain experts with queryable knowledge
@@ -61,6 +62,7 @@ core_implementation:
       hooks/:
         purpose: Lifecycle hooks (standard Python with hook_helpers.py)
         utils/hook_helpers.py: Shared hook utilities
+        kotadb/: Domain-specific hooks (pre-edit-context.py, agent-context.py, session-expertise.py)
       settings.json:
         purpose: Project-wide config (committed)
       settings.local.json:
@@ -74,10 +76,14 @@ core_implementation:
       purpose: Expert 4-agent pattern with standardized colors
     - path: .claude/agents/experts/<domain>/expertise.yaml
       purpose: Structured domain knowledge (400-600 lines target)
+    - path: .claude/agents/common/<guide-name>.md
+      purpose: Shared agent documentation (e.g., memory-usage.md)
     - path: .claude/hooks/<hook-name>.py
       purpose: Lifecycle hook using hook_helpers.py
+    - path: .claude/hooks/kotadb/<feature-hook>.py
+      purpose: Domain-specific hooks for KotaDB features
     - path: .claude/hooks/utils/hook_helpers.py
-      purpose: Shared hook utilities (read_hook_input, output_result, etc.)
+      purpose: Shared hook utilities (parse_stdin, output_context, run_kotadb_deps, etc.)
     - path: .claude/agents/agent-registry.json
       purpose: Machine-readable agent catalog with capability/model/tool indexes
 
@@ -119,7 +125,7 @@ key_operations:
 
   implement_hook:
     when: Need to run code on agent lifecycle events
-    events: [PreToolUse, PostToolUse, UserPromptSubmit, Stop]
+    events: [PreToolUse, PostToolUse, UserPromptSubmit, Stop, SubagentStart, SessionStart]
     approach: |
       1. Create .claude/hooks/<hook-name>.py with standard Python shebang:
          ```python
@@ -133,29 +139,170 @@ key_operations:
          sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
          from hooks.utils.hook_helpers import (
-             read_hook_input,
-             output_result,
-             get_file_path_from_input,
-             get_project_root,
+             parse_stdin,
+             output_continue,
+             output_context,
          )
 
          def main() -> None:
-             hook_input = read_hook_input()
+             hook_input = parse_stdin()
              # Hook logic here
-             output_result("continue", "Optional message")
+             output_continue()  # or output_context(message)
 
          if __name__ == "__main__":
              main()
          ```
-      2. Exit via output_result("continue") or output_result("block")
+      2. Exit via output_continue() or output_context(message)
       3. Configure in .claude/settings.json hooks object
       4. Use matcher for tool-specific targeting
     kotadb_conventions:
       - NEVER use print() - use sys.stdout.write() per logging standards
       - Import from hooks.utils.hook_helpers for shared utilities
       - Use standard Python shebang (#!/usr/bin/env python3), NOT uv
+      - Always exit 0 (never block on errors, warn to stderr)
+      - Keep output under 500 tokens for performance
     examples:
-      - auto_linter.py: PostToolUse hook for JS/TS file linting
+      - pre-edit-context.py: PreToolUse hook for dependency awareness
+      - agent-context.py: SubagentStart hook for file context injection
+      - session-expertise.py: SessionStart hook for dynamic expertise
+    timestamp: 2026-02-03
+    evidence: commit d671d51 context seeding hooks
+
+  organize_hooks_by_domain:
+    when: Creating domain-specific hooks beyond general lifecycle hooks
+    approach: |
+      1. Create .claude/hooks/<domain>/ subdirectory for related hooks
+      2. Place domain-specific hooks in subdirectory (e.g., .claude/hooks/kotadb/)
+      3. Keep hook_helpers.py in .claude/hooks/utils/ for shared utilities
+      4. Update sys.path.insert to account for subdirectory depth:
+         ```python
+         # From .claude/hooks/kotadb/my-hook.py
+         sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+         # Now can import from hooks.utils.hook_helpers
+         ```
+    rationale: |
+      As hook count grows, subdirectory organization prevents .claude/hooks/ clutter.
+      Domain-specific hooks (kotadb/, linting/, validation/) grouped for discoverability.
+      Shared utilities remain accessible via relative imports.
+    examples:
+      - .claude/hooks/kotadb/pre-edit-context.py - Dependency context on edits
+      - .claude/hooks/kotadb/agent-context.py - File context for spawned agents
+      - .claude/hooks/kotadb/session-expertise.py - Dynamic expertise at session start
+      - .claude/hooks/kotadb/memory-recall.py - Memory layer integration
+    pitfalls:
+      - what: Not updating sys.path.insert for subdirectory depth
+        instead: Use os.path.dirname twice for hooks in subdirectories
+        reason: Import resolution fails if path doesn't reach parent .claude/hooks/
+    timestamp: 2026-02-03
+    evidence: commit d671d51 .claude/hooks/kotadb/ organization
+
+  integrate_memory_layer_tools:
+    when: Adding memory layer MCP tools to agents for cross-session learning
+    approach: |
+      1. Add memory MCP tools to agent frontmatter tools array:
+         ```yaml
+         tools:
+           - Read
+           - Write
+           - mcp__kotadb-bunx__search_decisions
+           - mcp__kotadb-bunx__search_failures
+           - mcp__kotadb-bunx__search_patterns
+           - mcp__kotadb-bunx__record_decision
+           - mcp__kotadb-bunx__record_failure
+           - mcp__kotadb-bunx__record_insight
+         ```
+      2. Add "Memory Integration" section to agent prompt BEFORE Workflow:
+         ```markdown
+         ## Memory Integration
+
+         Before implementing, search for relevant past context:
+
+         1. **Check Past Failures**
+            search_failures("relevant keywords from your task")
+            Apply learnings to avoid repeating mistakes.
+
+         2. **Check Past Decisions**
+            search_decisions("relevant architectural keywords")
+            Follow established patterns and rationale.
+
+         3. **Check Discovered Patterns**
+            search_patterns(pattern_type: "relevant-type")
+            Use consistent patterns across implementations.
+
+         **During Implementation:**
+         - Record significant architectural decisions with record_decision
+         - Record failed approaches immediately with record_failure
+         - Record workarounds or discoveries with record_insight
+         ```
+      3. Create shared documentation at .claude/agents/common/memory-usage.md
+      4. Apply to build and improve agents (plan/question agents typically read-only)
+    rationale: |
+      Memory layer enables cross-session learning. Agents consult past failures,
+      decisions, and patterns before implementing. Recording during work creates
+      institutional knowledge for future sessions.
+    examples:
+      - agent-authoring-build-agent.md: Search failures before creating agents
+      - api-build-agent.md: Check patterns for endpoint conventions
+      - database-improve-agent.md: Record schema migration decisions
+    pitfalls:
+      - what: Adding memory tools without prompt guidance
+        instead: Always add Memory Integration section with examples
+        reason: Tools alone don't teach agents how/when to use memory
+      - what: Only adding record_* tools without search_* tools
+        instead: Add both search and record tools for complete lifecycle
+        reason: Agents need to consult AND contribute to memory
+    timestamp: 2026-02-03
+    evidence: commits a2c7435 #122, b00aae5 #121 memory integration
+
+  implement_context_seeding_hooks:
+    when: Injecting dynamic context into agents/tools based on runtime state
+    approach: |
+      1. Identify context trigger: PreToolUse (before edits), SubagentStart (before spawning), SessionStart (session init)
+      2. Create hook in .claude/hooks/kotadb/<hook-name>.py
+      3. Use hook_helpers utilities:
+         - parse_stdin() - Read hook input JSON
+         - extract_file_path(hook_input) - Get file from Edit/Write tool
+         - extract_agent_info(hook_input) - Get agent spawn details
+         - run_kotadb_deps(file_path) - Query dependency graph
+         - format_dependency_alert(deps) - Format < 500 token output
+         - output_context(message) - Inject context into agent/tool
+         - output_continue() - No context, proceed normally
+      4. Configure in settings.json with matcher:
+         ```json
+         {
+           "hooks": {
+             "PreToolUse": [{
+               "matcher": "Edit|Write|MultiEdit",
+               "hooks": [{
+                 "type": "command",
+                 "command": "python3 .claude/hooks/kotadb/pre-edit-context.py"
+               }]
+             }]
+           }
+         }
+         ```
+      5. Keep output under 500 tokens (token budget constraint)
+      6. Always exit 0 (never block on errors)
+    use_cases:
+      - PreToolUse + Edit: Warn about file dependents before editing
+      - SubagentStart + build: Inject file dependency context into spawned agent
+      - SessionStart: Provide dynamic expertise from recent patterns/files
+    examples:
+      - pre-edit-context.py: "⚠️ This file has 5 dependents that may need updates"
+      - agent-context.py: "Files mentioned in task: src/api/routes.ts (3 dependents)"
+      - session-expertise.py: "Recent activity: database schema changes, 12 migrations"
+    pitfalls:
+      - what: Exceeding 500 token output limit
+        instead: Limit to top 10-15 files, summarize with counts
+        reason: Large context injection slows agent response
+      - what: Blocking on errors (exit non-zero)
+        instead: Log to stderr, output_continue()
+        reason: Broken hooks shouldn't halt workflows
+      - what: Using print() instead of output_context()
+        instead: Use hook_helpers output functions
+        reason: Structured output ensures proper context injection
+    timestamp: 2026-02-03
+    evidence: commit d671d51 #116 context seeding implementation
 
   create_expert_domain:
     when: Adding new expert domain with queryable expertise
@@ -172,10 +319,12 @@ key_operations:
          - model: sonnet
          - color: green
          - tools: [Read, Write, Edit, Glob, Grep, Bash]
+         - Add memory layer tools if applicable
       5. Create <domain>-improve-agent.md:
          - model: sonnet
          - color: purple
          - tools: [Read, Write, Edit, Glob, Grep, Bash, Task]
+         - Add memory layer tools
       6. Create <domain>-question-agent.md:
          - model: haiku
          - color: cyan
@@ -269,6 +418,7 @@ key_operations:
       - Matcher enables tool-specific hooks (e.g., PostToolUse only for Edit)
       - Valid JSON (no trailing commas)
       - Hook commands use python3, not uv
+      - Hooks support SubagentStart and SessionStart events (new in recent Claude Code)
 
   update_do_command_for_expert:
     when: Adding new expert domain to /do orchestration
@@ -291,6 +441,7 @@ key_operations:
     rationale: |
       /do command uses keyword-based classification to route to correct expert.
       Each domain needs detection patterns, examples, and orchestration updates.
+      
   tool_permissions_philosophy:
     timestamp: 2026-01-28
     evidence: commit 446e999 tool permissions fix for 20 expert agents
@@ -311,11 +462,13 @@ key_operations:
       - GRANT: [Read, Write, Edit, Glob, Grep, Bash]
       - Bash enables: type-checking (bunx tsc), test runs (bun test), linting
       - Rationale: Build agents implement and should verify their work
+      - Memory tools: Add search_*/record_* for cross-session learning
 
       Improve agents (purple, sonnet):
       - GRANT: [Read, Write, Edit, Glob, Grep, Bash, Task]
       - Task enables: spawning sub-agents for complex analysis
       - Rationale: Improve agents analyze patterns and may delegate to experts
+      - Memory tools: Add search_*/record_* for extracting learnings
 
       Question agents (cyan, haiku):
       - GRANT: [Read, Glob, Grep]
@@ -357,6 +510,12 @@ key_operations:
       - mcp__kotadb-bunx__search_dependencies
       - mcp__kotadb-bunx__analyze_change_impact
       - mcp__kotadb-bunx__list_recent_files
+      - mcp__kotadb-bunx__search_decisions
+      - mcp__kotadb-bunx__search_failures
+      - mcp__kotadb-bunx__search_patterns
+      - mcp__kotadb-bunx__record_decision
+      - mcp__kotadb-bunx__record_failure
+      - mcp__kotadb-bunx__record_insight
     
     incorrect_naming:
       - mcp__kotadb__search_code (WRONG - missing transport suffix)
@@ -399,6 +558,7 @@ key_operations:
       - Document tool selection criteria in CLAUDE.md for user clarity
       - Add tool usage guidance to agent prompts for correct usage patterns
       - Validate MCP tool names match actual server configuration
+      
 decision_trees:
   command_vs_agent_vs_expert:
     question: What am I creating?
@@ -429,6 +589,24 @@ decision_trees:
         location: .claude/agents/experts/<domain>/expertise.yaml
       - file: Orchestrator commands
         location: .claude/commands/experts/orchestrators/
+      - file: Shared agent documentation
+        location: .claude/agents/common/
+
+  hook_event_selection:
+    question: Which hook event should I use?
+    options:
+      - if: Need to inspect/modify before tool execution
+        then: PreToolUse (e.g., dependency warnings before Edit)
+      - if: Need to validate/log after tool execution
+        then: PostToolUse (e.g., linting after file changes)
+      - if: Need to inject context when spawning agents
+        then: SubagentStart (e.g., file dependencies for build agent)
+      - if: Need to provide session-wide context at start
+        then: SessionStart (e.g., recent patterns, key files)
+      - if: Need to act on user prompt submission
+        then: UserPromptSubmit (e.g., request classification)
+      - if: Need to cleanup or log at session end
+        then: Stop (e.g., save session insights)
 
 patterns:
   expert_domain_4agent:
@@ -436,8 +614,8 @@ patterns:
       .claude/agents/experts/<domain>/
       ├── expertise.yaml (400-600 lines target, 1000 max)
       ├── <domain>-plan-agent.md (yellow, sonnet, Read/Glob/Grep/Write/Bash)
-      ├── <domain>-build-agent.md (green, sonnet, Read/Write/Edit/Glob/Grep/Bash)
-      ├── <domain>-improve-agent.md (purple, sonnet, all + Bash + Task)
+      ├── <domain>-build-agent.md (green, sonnet, Read/Write/Edit/Glob/Grep/Bash + memory tools)
+      ├── <domain>-improve-agent.md (purple, sonnet, all + Bash + Task + memory tools)
       └── <domain>-question-agent.md (cyan, haiku, Read/Glob/Grep)
     color_coding:
       plan: yellow (analysis, planning)
@@ -448,7 +626,8 @@ patterns:
       pros: [Plan-build-improve lifecycle, Color-coded roles, Queryable expertise]
       cons: [5 files per domain, Requires registry updates]
     active_domains:
-      timestamp: 2026-01-28
+      timestamp: 2026-02-03
+      count: 9
       list:
         - claude-config: .claude/ configuration management
         - agent-authoring: Agent creation and modification
@@ -457,6 +636,8 @@ patterns:
         - testing: Antimocking, Bun tests, SQLite test patterns
         - indexer: AST parsing, symbol extraction, code analysis
         - github: Issues, PRs, branches, GitHub CLI workflows
+        - automation: ADW workflows, agent orchestration, worktree isolation
+        - documentation: Documentation management, content organization
 
   agent_frontmatter_format:
     kotadb_style: |
@@ -468,6 +649,8 @@ patterns:
         - Glob
         - Grep
         - mcp__kotadb-bunx__search_code
+        - mcp__kotadb-bunx__search_decisions
+        - mcp__kotadb-bunx__record_failure
       model: haiku|sonnet|opus
       color: yellow|green|purple|cyan
       constraints:
@@ -479,6 +662,7 @@ patterns:
       - model and color optional but recommended for expert agents
       - Description MUST NOT contain colons
       - MCP tools use mcp__server__tool format
+      - Memory layer tools for build/improve agents
 
   command_template_category:
     categories:
@@ -496,17 +680,88 @@ patterns:
   hook_helpers_pattern:
     usage: |
       from hooks.utils.hook_helpers import (
-          read_hook_input,      # Parse JSON from stdin
-          output_result,        # Write JSON result to stdout
-          get_file_path_from_input,  # Extract file path from hook input
-          get_project_root,     # Get CLAUDE_PROJECT_DIR or cwd
-          is_js_ts_file,        # Check if file is JS/TS
+          parse_stdin,              # Parse JSON from stdin
+          output_continue,          # Continue without context injection
+          output_context,           # Inject context message
+          extract_file_path,        # Extract file from Edit/Write tool input
+          extract_agent_info,       # Extract agent spawn details
+          run_kotadb_deps,          # Query dependency graph
+          format_dependency_alert,  # Format dependency warning
+          get_kotadb_command,       # Get CLI command (dev vs prod)
       )
     conventions:
       - NEVER use print() - violates logging standards
       - Always use sys.stdout.write() for output
       - Import hook_helpers from hooks.utils
       - Add sys.path.insert for parent directory access
+      - Keep context output under 500 tokens
+      - Always exit 0 (never block on errors)
+    timestamp: 2026-02-03
+    evidence: commit d671d51 hook_helpers.py utilities
+
+  context_seeding_pattern:
+    structure: |
+      # Hook: .claude/hooks/kotadb/pre-edit-context.py
+      # Trigger: PreToolUse with matcher "Edit|Write|MultiEdit"
+      # Purpose: Warn about file dependents before editing
+
+      def main() -> None:
+          hook_input = parse_stdin()
+          if not hook_input:
+              output_continue()
+              return
+          
+          file_path = extract_file_path(hook_input)
+          if not file_path:
+              output_continue()
+              return
+          
+          # Query KotaDB for dependency information
+          deps_result = run_kotadb_deps(file_path, format="json", depth=1)
+          
+          if deps_result.get("error") or not deps_result.get("dependents"):
+              output_continue()
+              return
+          
+          # Format and inject context
+          alert = format_dependency_alert(deps_result, max_files=10)
+          output_context(alert)
+    trade_offs:
+      pros: [Dynamic awareness, Prevents breaking changes, No manual context, Just-in-time info]
+      cons: [500 token budget, CLI query overhead, Requires indexed repo]
+    timestamp: 2026-02-03
+    evidence: commit d671d51 #116
+
+  memory_integration_pattern:
+    structure: |
+      # Agent: api-build-agent.md
+      # Section: Memory Integration (before Workflow)
+
+      ## Memory Integration
+
+      Before implementing, search for relevant past context:
+
+      1. **Check Past Failures**
+         search_failures("relevant keywords from your task")
+         Apply learnings to avoid repeating mistakes.
+
+      2. **Check Past Decisions**
+         search_decisions("relevant architectural keywords")
+         Follow established patterns and rationale.
+
+      3. **Check Discovered Patterns**
+         search_patterns(pattern_type: "relevant-type")
+         Use consistent patterns across implementations.
+
+      **During Implementation:**
+      - Record significant architectural decisions with record_decision
+      - Record failed approaches immediately with record_failure
+      - Record workarounds or discoveries with record_insight
+    trade_offs:
+      pros: [Cross-session learning, Avoids repeated mistakes, Institutional knowledge, Pattern consistency]
+      cons: [Requires MCP tools, Search overhead, Recording discipline needed]
+    timestamp: 2026-02-03
+    evidence: commits a2c7435 #122, b00aae5 #121
 
   agent_registry_structure:
     sections:
@@ -547,7 +802,9 @@ best_practices:
     - Agents in .claude/agents/, commands in .claude/commands/
     - Expert domains: agents/experts/<domain>/ (4-agent + expertise.yaml)
     - General agents at root level: build-agent.md, scout-agent.md, review-agent.md
+    - Shared agent docs: agents/common/ (memory-usage.md, etc.)
     - Expertise.yaml: 400-600 lines target, 1000 hard limit
+    - Hooks by domain: hooks/<domain>/ for related hooks (hooks/kotadb/)
 
   commands:
     - Include Template Category after title
@@ -563,6 +820,7 @@ best_practices:
     - CRITICAL: Never use colons in description field
     - Add MCP tools where appropriate (mcp__kotadb-bunx__*)
     - Apply "permissive tools + strict prompts" philosophy
+    - Add memory layer tools to build/improve agents for cross-session learning
 
 
   mcp_tools:
@@ -573,18 +831,25 @@ best_practices:
     - Add tool usage guidance sections to core agent prompts
     - Prefer MCP tools for semantic search, dependencies, impact analysis
     - Fallback to Grep for exact regex or unindexed files
+    - Memory tools: search_decisions, search_failures, search_patterns, record_decision, record_failure, record_insight
+    
   hooks:
     - Standard Python shebang (#!/usr/bin/env python3)
     - Import from hooks.utils.hook_helpers
     - NEVER use print() - use sys.stdout.write()
-    - Use output_result() for structured responses
+    - Use output_continue() or output_context() for responses
     - Configure in settings.json with matchers
+    - Organize domain-specific hooks in subdirectories (hooks/kotadb/)
+    - Keep context output under 500 tokens
+    - Always exit 0 (never block on errors, warn to stderr)
+    - New events: SubagentStart, SessionStart for context injection
 
   settings:
     - settings.json: project-wide (committed)
     - settings.local.json: local overrides (gitignored)
     - Valid JSON (no trailing commas)
     - Hook commands use python3
+    - Hook events: PreToolUse, PostToolUse, SubagentStart, SessionStart, UserPromptSubmit, Stop
 
   expert_expansion:
     timestamp: 2026-01-28
@@ -594,6 +859,15 @@ best_practices:
       - Keep /do domain detection patterns specific and non-overlapping
       - Update all 3 files (CLAUDE.md, do.md, agent-registry.json) atomically
       - Grant consistent tool permissions across agent types within domain
+
+  memory_layer:
+    timestamp: 2026-02-03
+    insights:
+      - Add memory MCP tools to build/improve agents for cross-session learning
+      - Create Memory Integration section in agent prompts BEFORE Workflow
+      - Document memory tools in shared guide (.claude/agents/common/memory-usage.md)
+      - Search before implementing (failures, decisions, patterns)
+      - Record during implementing (decisions, failures, insights)
 
 known_issues:
   - issue: Colons in frontmatter description values break YAML parsing
@@ -616,6 +890,7 @@ known_issues:
     impact: Inconsistent output, potential buffering issues
     resolution: Use sys.stdout.write() per KotaDB conventions
     status: enforced via code review
+    
   - issue: Tool permissions too restrictive for agent workflows
     impact: Agents silently fail to complete tasks (can't write specs, run tests)
     resolution: Apply "permissive tools + strict prompts" philosophy
@@ -644,23 +919,33 @@ potential_enhancements:
   - Tool permission consistency checker across agent types
   - Documentation accuracy validation (check all referenced commands/files exist)
   - Spec file location consistency enforcement (docs/specs/ vs .claude/.cache/specs/)
+  - Hook output token budget enforcement (warn if > 500 tokens)
+  - Memory layer integration test suite (verify search/record workflows)
 
 
 stability:
   convergence_indicators:
-    insight_rate_trend: growing
+    insight_rate_trend: expanding
     contradiction_count: 0
-    new_patterns_added_this_cycle: 1
-    patterns_updated_this_cycle: 1
-    last_reviewed: 2026-02-02
+    new_patterns_added_this_cycle: 4
+    patterns_updated_this_cycle: 2
+    last_reviewed: 2026-02-03
     utility_ratio: 1.0
     notes: |
-      MCP tool naming and tool selection guidance cycle:
-      - Added mcp_tool_naming_and_usage operation (key_operations)
-      - Pattern: Server names include transport method (kotadb-bunx vs kotadb)
-      - Impact: 13 files corrected (commit 2705560, issue #84)
-      - Added mcp_tools best practices section
-      - Documentation pattern: Tool selection decision tree in CLAUDE.md
-      - Agent integration: Add "KotaDB MCP Tool Usage" sections to core agents
-      - Lesson: MCP tool names derived from Claude Desktop config server names
-      - Size: 664 lines (above 600 target, under 800 warning threshold)
+      Hook organization and memory layer integration cycle:
+      - Added organize_hooks_by_domain operation (key_operations)
+      - Added integrate_memory_layer_tools operation (key_operations)
+      - Added implement_context_seeding_hooks operation (key_operations)
+      - Updated implement_hook with new events (SubagentStart, SessionStart)
+      - Added context_seeding_pattern (patterns)
+      - Added memory_integration_pattern (patterns)
+      - Updated hook_helpers_pattern with new utilities
+      - Updated directory_structure with hooks/kotadb/ and agents/common/
+      - Updated key_files with domain-specific hooks and common docs
+      - Added hook_event_selection decision tree
+      - Updated best_practices with hook organization and memory layer guidance
+      - Impact: 3 commits (d671d51 #116, a2c7435 #122, b00aae5 #121)
+      - Files affected: 20+ (hooks, agents, settings.json, common docs)
+      - Major features: Context seeding hooks, memory layer integration, hook organization
+      - Domain showing continued expansion with sophisticated integration patterns
+      - Size: 879 lines (above 800 warning threshold, cleanup recommended next cycle)

--- a/.claude/agents/experts/database/expertise.yaml
+++ b/.claude/agents/experts/database/expertise.yaml
@@ -165,6 +165,122 @@ key_operations:
       - "Defense-in-depth: whitelist + table existence check"
     evidence: "app/src/sync/deletion-manifest.ts, 2026-02-02"
 
+  repository_resolution:
+    when: MCP tools accepting repository parameters
+    pattern: |
+      // Support both UUID and full_name formats
+      import { resolveRepositoryIdentifierWithError } from "@mcp/repository-resolver";
+      
+      const repoResult = resolveRepositoryIdentifierWithError(params.repository);
+      if ("error" in repoResult) {
+        return { error: repoResult.error };
+      }
+      const repositoryId = repoResult.id;
+    fallback: "If no repository provided, fall back to most recently created repo"
+    validation: "UUID regex: /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i"
+    error_messages:
+      - "No repositories found. Please index a repository first using index_repository tool."
+      - "Repository not found: {identifier}. Use a valid repository UUID or full_name."
+    evidence: "Commits 60b4997, 9adc86f (issue #137), app/src/mcp/repository-resolver.ts, 2026-02-03"
+
+  cascade_deletion_with_fts5:
+    when: Deleting indexed files and their dependent data
+    pattern: |
+      // Schema with CASCADE
+      CREATE TABLE indexed_files (...);
+      CREATE TABLE indexed_symbols (
+        file_id TEXT NOT NULL,
+        FOREIGN KEY (file_id) REFERENCES indexed_files(id) ON DELETE CASCADE
+      );
+      
+      // FTS5 triggers auto-cleanup on base table DELETE
+      CREATE TRIGGER indexed_files_fts_ad AFTER DELETE ON indexed_files BEGIN
+        INSERT INTO indexed_files_fts(indexed_files_fts, rowid, ...) 
+        VALUES ('delete', old.rowid, ...);
+      END;
+      
+      // TypeScript deletion
+      db.run(`DELETE FROM indexed_files WHERE id = ?`, [fileId]);
+      // Automatically deletes: symbols, references, FTS5 entries
+    benefits:
+      - "Single DELETE statement cleans up entire dependency tree"
+      - "FTS5 triggers maintain search index consistency"
+      - "No manual cleanup needed for child tables"
+    evidence: "app/src/api/queries.ts deleteFileByPath(), commit aa4fcf4, 2026-02-03"
+
+  batch_deletion_transactional:
+    when: Deleting multiple files atomically
+    pattern: |
+      function deleteFilesByPaths(repoId: string, paths: string[]): DeleteResult {
+        const deleted: string[] = [];
+        db.transaction(() => {
+          for (const path of paths) {
+            const file = db.queryOne<{ id }>(
+              `SELECT id FROM indexed_files WHERE repository_id = ? AND path = ?`,
+              [repoId, normalizePath(path)]
+            );
+            if (file) {
+              db.run(`DELETE FROM indexed_files WHERE id = ?`, [file.id]);
+              deleted.push(path);
+            }
+          }
+        });
+        return { deletedCount: deleted.length, deletedPaths: deleted };
+      }
+    benefits:
+      - "All-or-nothing: either all files deleted or none"
+      - "Consistent state even if error mid-batch"
+      - "Single WAL checkpoint instead of N checkpoints"
+    evidence: "app/src/api/queries.ts deleteFilesByPathsInternal(), commit aa4fcf4, 2026-02-03"
+
+  internal_external_function_pattern:
+    when: Writing database functions that need testability
+    pattern: |
+      // Internal version accepts db for testing
+      function operationInternal(db: KotaDatabase, params...): Result {
+        return db.query(...);
+      }
+      
+      // Public version uses global database
+      export function operation(params...): Result {
+        return operationInternal(getGlobalDatabase(), params);
+      }
+      
+      // Test version explicitly accepts db
+      export function operationLocal(db: KotaDatabase, params...): Result {
+        return operationInternal(db, params);
+      }
+    benefits:
+      - "Tests can inject in-memory database"
+      - "Production code uses singleton global db"
+      - "Single implementation, multiple interfaces"
+    naming: "*Internal() for impl, *() for production, *Local() for tests"
+    evidence: "app/src/api/queries.ts pattern throughout, 2026-02-03"
+
+  memory_layer_schema:
+    when: Implementing cross-session agent learning
+    tables:
+      decisions:
+        purpose: "Record architectural and design decisions"
+        fts5_columns: "title, context, decision, rationale"
+        scope_enum: "architecture | pattern | convention | workaround"
+      failures:
+        purpose: "Track failed approaches to avoid repeating mistakes"
+        fts5_columns: "title, problem, approach, failure_reason"
+      patterns:
+        purpose: "Store detected codebase patterns with examples"
+        indexed_on: "pattern_type, file_path"
+      insights:
+        purpose: "Session discoveries and workarounds"
+        fts5_columns: "content"
+        type_enum: "discovery | failure | workaround"
+    common_patterns:
+      - "All tables have optional repository_id FK with CASCADE"
+      - "JSON arrays in TEXT for alternatives/related_files"
+      - "FTS5 virtual tables for searchability"
+      - "Automatic FTS5 sync via ai/ad/au triggers"
+    evidence: "Commit 25ecbc2 (issue #99), app/src/db/sqlite-schema.sql section 10, 2026-02-03"
+
   wal_configuration:
     pragmas: |
       PRAGMA journal_mode = WAL;
@@ -269,6 +385,12 @@ best_practices:
     - schema_migrations table
     - test rollback
 
+  testability:
+    - Internal/External function pattern
+    - Test functions accept db parameter
+    - Production functions use getGlobalDatabase()
+    - Name test variants with *Local suffix
+
 known_issues:
   - issue: FTS5 syntax errors with hyphens/multi-word
     resolution: "escapeFts5Term() (commit 5af086f)"
@@ -283,16 +405,23 @@ known_issues:
     resolution: "Checkpoint periodically, smaller batches"
 
 stability:
-  last_reviewed: 2026-02-02
+  last_reviewed: 2026-02-03
   insight_rate_trend: accelerating
   contradiction_count: 0
   notes: |
-    Major update (2026-02-02) - added sync and security patterns:
+    Major update (2026-02-03) - added patterns from auto-indexing and memory layer:
+    - Repository resolution: UUID vs full_name flexibility with helpful errors
+    - CASCADE deletion with FTS5: Single DELETE cleans up all dependencies
+    - Batch deletion transactional: All-or-nothing multi-file deletion
+    - Internal/External function pattern: Testability via db parameter injection
+    - Memory layer schema: decisions, failures, patterns, insights tables with FTS5
+    
+    Previous update (2026-02-02) - sync and security patterns:
     - Deletion manifest security controls (whitelist, validation, DoS protection)
     - JSONL sync architecture with explicit deletion tracking
     - Single source of truth lessons learned from dependency_graph removal
-
-    Previous consolidation (2026-01-30) preserved:
+    
+    Consolidated (2026-01-30):
     - FTS5 + escapeFts5Term (issue #595)
     - Auto-init schema (issue #574)
     - Project-local storage (issue #592)

--- a/.claude/agents/experts/documentation/expertise.yaml
+++ b/.claude/agents/experts/documentation/expertise.yaml
@@ -291,6 +291,82 @@ key_operations:
       - No reviewer attribution
       - Incorrect navigation order
 
+
+  create_quickstart_documentation:
+    when: Providing rapid onboarding for new users (< 5 minutes)
+    approach: |
+      1. Create separate QUICKSTART.md focused on user journey (not technical details)
+      2. Start with value proposition and immediate benefit
+      3. Use conversational "Ask Claude" examples instead of tool names
+      4. Emphasize auto-indexing and zero-config setup
+      5. Keep installation steps minimal (2-3 steps max)
+      6. Show concrete examples of natural language queries
+      7. Include troubleshooting for first-use friction points
+    timestamp: 2026-02-03
+    evidence: Commit 22f036d - QUICKSTART.md separated from README
+    patterns:
+      - Separate quickstart from technical README
+      - User-focused language (Ask Claude) vs developer-focused (tool parameters)
+      - "What you can do" examples before "how it works" explanations
+      - Troubleshooting section for common first-use issues
+    code_example: |
+      # KotaDB Quickstart
+      
+      **Ask Claude about your code, get instant answers.**
+      
+      ## Install (2 minutes)
+      
+      ### 1. Add to Claude Code
+      [minimal config]
+      
+      ### 2. Restart Claude Code
+      That's it. No indexing commands, no configuration files.
+      
+      ## Your First Query
+      
+      Open any project and ask Claude:
+      > "What files depend on src/api/routes.ts?"
+    pitfalls:
+      - Mixing technical implementation details into quickstart
+      - Showing tool names instead of natural language examples
+      - Requiring manual indexing steps (highlights auto-indexing)
+      - Overwhelming users with all features upfront
+
+  document_tool_tiers:
+    when: Exposing configurable feature sets via CLI flags
+    approach: |
+      1. Create comparison table with tier names, tool counts, descriptions
+      2. Show concrete CLI examples for each tier
+      3. Document tier in both README and CLI help text
+      4. Provide MCP configuration examples with toolset selection
+      5. Include tool count in tier description for transparency
+      6. Use progressive disclosure (minimal to full feature sets)
+    timestamp: 2026-02-03
+    evidence: Current uncommitted changes - README.md and app/src/cli.ts
+    patterns:
+      - Tabular format for tier comparison
+      - Tool count transparency in descriptions
+      - Multiple configuration examples showing different tiers
+      - CLI help text mirrors README documentation
+    code_example: |
+      ### Tool Tiers
+      
+      | Tier | Tools | Description |
+      |------|-------|-----------|
+      | `core` | 6 | Essential code intelligence |
+      | `default` | 8 | Core + sync tools |
+      | `memory` | 14 | Default + memory layer |
+      | `full` | 20 | All tools |
+      
+      Example configurations:
+      - `bunx kotadb@next --stdio --toolset core` (minimal: 6 tools)
+      - `bunx kotadb@next --stdio` (default: 8 tools)
+    pitfalls:
+      - Inconsistent tool counts between README and implementation
+      - Missing CLI examples for each tier
+      - Unclear tier progression (why choose one over another)
+      - No MCP configuration examples showing tier selection
+
 decision_trees:
   documentation_validation_strategy:
     question: How should I validate this documentation section?
@@ -432,6 +508,37 @@ patterns:
       - README.md: project overview, installation quick start
       - commands/README.md: directory structure, command categories
 
+  user_focused_documentation_pattern:
+    structure: Natural language examples using "Ask Claude" phrasing
+    usage: Tool capability documentation for end users
+    trade_offs: Approachability vs technical precision
+    timestamp: 2026-02-03
+    evidence: QUICKSTART.md (Commit 22f036d)
+    example: |
+      ### search_dependencies
+      **Understand what depends on what.**
+      
+      Ask Claude:
+      - "What files import this module?"
+      - "What would break if I delete this file?"
+      - "Show me the dependency tree for the auth system"
+    rationale: |
+      Users think in terms of questions they want answered, not tool parameters.
+      Showing natural language examples demonstrates capability more effectively
+      than technical parameter documentation.
+
+  separate_quickstart_pattern:
+    structure: QUICKSTART.md for new users, README.md for technical details
+    usage: Projects with both user and developer audiences
+    trade_offs: Maintenance overhead vs improved onboarding experience
+    timestamp: 2026-02-03
+    evidence: Commit 22f036d - Added QUICKSTART.md alongside README
+    rationale: |
+      README serves multiple audiences (contributors, integrators, users).
+      Separate quickstart allows optimizing for 5-minute user onboarding
+      without cluttering technical reference material.
+
+
 best_practices:
   api_documentation:
     - Cross-reference all MCP tools with app/src/mcp/tools.ts
@@ -515,6 +622,12 @@ known_issues:
     status: Resolved (2026-02-02)
     evidence: Commit cbf171b (Issue #77)
 
+  - issue: README mixed user onboarding with technical reference
+    impact: New users overwhelmed by installation complexity
+    resolution: Created separate QUICKSTART.md for 5-minute onboarding
+    status: Resolved (2026-02-03)
+    evidence: Commit 22f036d
+
 potential_enhancements:
   - Automated documentation validation against implementation
   - CLI command testing in CI/CD pipeline
@@ -526,13 +639,14 @@ potential_enhancements:
 
 stability:
   convergence_indicators:
-    insight_rate_trend: active (3 new patterns this cycle)
+    insight_rate_trend: active (4 new patterns this cycle)
     contradiction_count: 0
-    last_reviewed: 2026-02-02
+    last_reviewed: 2026-02-03
     notes: |
-      Second review cycle. Extracted patterns from Issues #77 (phantom commands)
-      and #84 (MCP tool naming). Added key_operations for slash command validation,
-      cross-file sync, and tool selection guidance. Added patterns for phantom
-      command prevention, tool selection guidance, and cross-file sync. Three new
-      known_issues resolved. Domain showing healthy pattern accumulation without
-      contradictions. Next review should assess if patterns are stabilizing.
+      Third review cycle. Extracted patterns from quickstart separation (#123),
+      comprehensive docs update (#124), and tool tier documentation (uncommitted).
+      Added key_operations for quickstart creation and tool tier documentation.
+      Added patterns for user-focused documentation and separate quickstart files.
+      One new known_issue resolved. Domain continues healthy pattern accumulation
+      with focus on user experience improvements. Patterns show evolution from
+      technical accuracy (cycles 1-2) to user-focused approachability (cycle 3).

--- a/.claude/agents/experts/indexer/expertise.yaml
+++ b/.claude/agents/experts/indexer/expertise.yaml
@@ -41,50 +41,14 @@ core_implementation:
       import-resolver.ts: Import path resolution utilities
       path-resolver.ts: TypeScript path alias resolution (tsconfig.json parsing)
       dependency-extractor.ts: Dependency graph construction
-      circular-detector.ts: Circular dependency detection algorithms
       storage.ts: SQLite storage layer with transactional writes
-      repos.ts: Repository management functions
-      extractors.ts: High-level extraction orchestration
-      parsers.ts: File type detection and parsing coordination
-    
-
-  key_files:
-    - path: app/src/indexer/ast-parser.ts
-      purpose: AST parsing with graceful error handling
-      exports: parseFile, isSupportedForAST
-    - path: app/src/indexer/regex-fallback.ts
-      purpose: Regex-based symbol extraction fallback for unparseable files
-      exports: extractSymbolsWithRegex, RegexExtractedSymbol
-    - path: app/src/indexer/symbol-extractor.ts
-      purpose: Symbol extraction from AST
-      exports: extractSymbols, Symbol, SymbolKind
-    - path: app/src/indexer/reference-extractor.ts
-      purpose: Reference extraction from AST with re-export and dynamic import support
-      exports: extractReferences, Reference, ReferenceType
-    - path: app/src/indexer/import-resolver.ts
-      purpose: Import path resolution
-      exports: resolveImport, resolveExtensions, handleIndexFiles
-    - path: app/src/indexer/path-resolver.ts
-      purpose: TypeScript path alias resolution
-      exports: parseTsConfig, resolvePathAlias, PathMappings
-    - path: app/src/indexer/dependency-extractor.ts
-      purpose: Dependency graph construction
-      exports: extractDependencies, DependencyEdge
-    - path: app/src/indexer/storage.ts
-      purpose: SQLite storage with atomic transactions
-      exports: storeIndexedData, StorageResult
-    - path: app/src/api/queries.ts
-      purpose: FTS5 search with proper term escaping, auto-indexing workflow integration
-      exports: searchFilesLocal, escapeFts5Term, runIndexingWorkflow, isRepositoryIndexed
-    - path: app/src/mcp/auto-index.ts
-      purpose: Auto-indexing utilities for "just works" behavior
-      exports: ensureRepositoryIndexed, detectRepositoryFromCwd, isPathIndexed
-    - path: app/src/sync/source-watcher.ts
-      purpose: File system watcher for automatic incremental re-indexing
-      exports: SourceWatcher, createSourceWatcher, startWatching, stopWatching
-    - path: app/src/indexer/incremental.ts
-      purpose: Incremental indexing API for changed file processing
-      exports: indexChangedFiles, deleteIndexedFiles, detectChangedFiles
+      incremental.ts: Incremental indexing API for changed file processing
+    app/src/sync/:
+      source-watcher.ts: File system watcher for automatic incremental re-indexing
+    app/src/mcp/:
+      auto-index.ts: Auto-indexing utilities for "just works" behavior
+    app/src/api/:
+      queries.ts: FTS5 search with proper term escaping, auto-indexing workflow integration
 
 key_operations:
   parse_ast:
@@ -101,118 +65,26 @@ key_operations:
          - Log warning with file path
          - Continue processing other files
          - Never throw on parse errors
-
-      Parser configuration:
-      ```typescript
-      parse(content, {
-        ecmaVersion: "latest",
-        sourceType: "module",
-        loc: true,        // Line/column information
-        range: true,      // Character range
-        comment: true,    // Preserve comments (for JSDoc)
-        tokens: true,     // Preserve tokens
-        filePath,         // For error messages
-      });
-      ```
-    examples:
-      - parseFile("src/utils.ts", content) -> TSESTree.Program | null
-      - isSupportedForAST("data.json") -> false
     pitfalls:
       - what: Throwing on parse errors
         instead: Return null and log error
         reason: Single bad file should not halt indexing
-      - what: Parsing JSON files
-        instead: Skip JSON files in isSupportedForAST
-        reason: JSON is not valid JavaScript program
-
 
   parse_ast_with_error_recovery:
     when: Parsing TypeScript/JavaScript with syntax errors that prevent normal AST generation
     approach: |
       1. Call parseFileWithRecovery(filePath, content) -> ParseResult
-         - Returns { ast, errors, partial } structure
-         - ast: TSESTree.Program | null (partial or null if recovery fails)
-         - errors: ParseError[] (with message, line, column)
-         - partial: boolean (true if AST recovered despite errors)
-      
       2. First attempt: Normal parsing (strict mode)
-         - Uses standard @typescript-eslint/parser options
-         - Returns ast with errors:[] and partial:false on success
+      3. Second attempt: Error-tolerant parsing with allowInvalidAST: true
+      4. Third attempt: Regex fallback (extractSymbolsWithRegex)
       
-      3. Second attempt: Error-tolerant parsing (if first fails)
-         - Enables allowInvalidAST: true option
-         - Enables errorOnUnknownASTType: false option
-         - Returns partial AST if recovery succeeds
-         - Sets partial:true flag to indicate recovery was used
-      
-      4. Third attempt: Regex fallback (if AST recovery fails completely)
-         - Call extractSymbolsWithRegex(content, filePath)
-         - Pattern-based extraction for basic symbols
-         - Marks symbols with metadata.extractionMethod: "regex"
-         - Returns limited symbol info without full AST structure
-      
-      Error recovery stages:
-      ```typescript
-      const result = parseFileWithRecovery(filePath, content);
-      
-      if (result.ast) {
-        // Success or partial recovery
-        if (result.partial) {
-          logger.warn(`Recovered partial AST for ${filePath}`, {
-            error_count: result.errors.length,
-            recovery: "partial"
-          });
-        }
-        const symbols = extractSymbols(result.ast, filePath);
-      } else if (result.errors.length > 0) {
-        // Complete failure - try regex fallback
-        logger.error(`AST parsing failed for ${filePath}`, {
-          error_count: result.errors.length,
-          first_error: result.errors[0]?.message
-        });
-        const symbols = extractSymbolsWithRegex(content, filePath);
-      }
-      ```
-      
-      Recovery capabilities:
-      Recovery capabilities:
-      - Minor syntax errors (missing semicolons handled by ASI)
-      - Unclosed braces (may recover valid nodes before error)
-      - Multiple syntax errors (attempts to extract valid sections)
-      - Complete failures (regex fallback for basic pattern matching)
-      
-      Regex fallback patterns:
-      - Functions: /export\s+(?:async\s+)?function\s+(\w+)/
-      - Classes: /export\s+(?:abstract\s+)?class\s+(\w+)/
-      - Interfaces: /export\s+interface\s+(\w+)/
-      - Types: /export\s+type\s+(\w+)\s*=/
-      - Enums: /export\s+(?:const\s+)?enum\s+(\w+)/
-      - Constants: /export\s+const\s+(\w+)/
-      - Arrow functions: /export\s+const\s+(\w+)\s*=\s*(?:async\s+)?\([^)]*\)\s*=>/
-      
-      Regex limitations:
-      - Cannot determine accurate end line (uses start line)
-      - Cannot extract JSDoc comments
-      - Cannot determine precise column positions
-      - May miss complex multi-line declarations
-      - May produce false positives in strings/comments
-      - Marks symbols with extractionMethod: "regex" metadata
-    examples:
-      - File with unclosed brace -> partial AST with nodes before error
-      - File with syntax error -> regex fallback extracts export patterns
-      - parseFileWithRecovery returns errors array with line numbers
+      Regex fallback patterns extract: functions, classes, interfaces, types, enums, constants
+      Limitations: No JSDoc, approximate positions, marked with extractionMethod: "regex"
     pitfalls:
       - what: Treating partial AST as fully validated
         instead: Check result.partial flag and handle appropriately
-        reason: Partial ASTs may have incomplete or invalid node structures
-      - what: Ignoring regex fallback symbols
-        instead: Use them despite limitations (better than nothing)
-        reason: Some symbol info is better than complete loss for broken files
-      - what: Not logging recovery attempts
-        instead: Log warnings for partial recovery, errors for complete failures
-        reason: Observability helps identify problematic files
     timestamp: 2026-02-02
-    evidence: "commit 38d4e96, PR #76/#92, app/src/indexer/ast-parser.ts, app/src/indexer/regex-fallback.ts"
+    evidence: "commit 38d4e96, PR #76/#92"
 
   auto_index_workflow:
     when: Tools need to ensure repository is indexed before execution
@@ -222,54 +94,25 @@ key_operations:
          - If repositoryParam provided -> check if it's a local path (has .git) or identifier
          - If no param -> auto-detect from process.cwd() using detectRepositoryFromCwd()
          - Generate identifier: "local/<directory-name>" for local repositories
-      3. Check if already indexed
-         - Query repositories table by full_name (identifier)
-         - Verify using isRepositoryIndexed(repositoryId) to check files exist
-         - Return existing repositoryId if properly indexed
-      4. Perform indexing if needed
-         - Create IndexRequest with repository, ref: "main", localPath
-         - Call runIndexingWorkflow(indexRequest) for full indexing
-         - Return wasIndexed: true with stats (filesIndexed, symbolsExtracted, etc.)
+      3. Check if already indexed using isRepositoryIndexed(repositoryId)
+      4. Perform indexing if needed via runIndexingWorkflow(indexRequest)
 
       Integration pattern:
       ```typescript
-      // In MCP tools before performing operations
       const autoResult = await ensureRepositoryIndexed(repository, localPath);
       const repositoryId = autoResult.repositoryId;
-
+      
       if (autoResult.wasIndexed) {
-        // First-time indexing occurred
-        logger.info("Auto-indexed repository", {
-          message: autoResult.message,
-          stats: autoResult.stats
-        });
+        logger.info("Auto-indexed repository", { stats: autoResult.stats });
       }
-
-      // Proceed with tool operation using repositoryId
+      
       const results = await searchCode(repositoryId, query);
       ```
-
-      Repository detection heuristics:
-      - Check for .git directory existence
-      - Use basename of directory for repository name
-      - Create "local/<name>" identifier for local repos
-      - Store absolute path as git_url for local repositories
-    examples:
-      - ensureRepositoryIndexed() from /path/to/myrepo -> auto-detects "local/myrepo"
-      - ensureRepositoryIndexed("/path/to/repo") -> detects path, creates "local/repo"
-      - ensureRepositoryIndexed("local/existing") -> finds existing, returns repositoryId
     pitfalls:
       - what: Not checking .git directory for path-based detection
         instead: Always verify .git exists before treating as local repository
-        reason: Prevents indexing non-git directories accidentally
-      - what: Using synchronous file system operations in MCP tools
-        instead: Use async ensureRepositoryIndexed for better performance
-        reason: MCP tools should be non-blocking
-      - what: Ignoring AutoIndexResult.wasIndexed flag
-        instead: Use flag to provide user feedback about indexing activity
-        reason: Users should know when first-time indexing occurs
     timestamp: 2026-02-03
-    evidence: "commit aa4fcf4, PR #35/#125, app/src/mcp/auto-index.ts, app/src/mcp/tools.ts"
+    evidence: "commit aa4fcf4, PR #35/#125"
 
   incremental_indexing:
     when: Re-indexing changed files without full repository scan
@@ -278,175 +121,61 @@ key_operations:
       2. Separate deleted files from added/modified
          - Deleted files: call deleteIndexedFiles() to remove from database
          - Added/Modified files: parse, extract, and store new data
-      3. For each file to index:
-         - Parse using parseSourceFile(absolutePath, repositoryRoot)
-         - Delete existing data if file was previously indexed
-         - Store file record with new metadata
-         - Extract symbols and references if AST-supported
-         - Resolve imports using path mappings from tsconfig.json
-      4. Return comprehensive results
-         - filesUpdated, filesDeleted, symbolsExtracted, referencesExtracted
-         - errors[] with { path, error } for failed files
+      3. For each file: parse, delete existing data, store file, extract symbols/references
+      4. Return comprehensive results with filesUpdated, filesDeleted, symbolsExtracted, errors[]
 
       ChangedFile format:
       ```typescript
       interface ChangedFile {
-        path: string;           // Relative path from repository root
+        path: string;
         status: "added" | "modified" | "deleted";
       }
       ```
-
-      Deletion handling:
-      - Uses CASCADE deletes: file -> symbols -> references
-      - Atomic transactions ensure consistency
-      - Batch deletions for performance
-
-      Error handling:
-      - Individual file failures don't halt entire operation
-      - Errors collected in result.errors array
-      - Failed files logged with Sentry integration
-
-      Path normalization:
-      - Convert absolute paths to relative for database consistency
-      - Handle Windows/Unix path separators
-      - Remove leading ./ prefixes
-    examples:
-      - Change detection: git diff --name-status -> ChangedFile[]
-      - File watcher: debounced filesystem events -> incremental indexing
-      - Manual re-index: specific file paths -> targeted updates
     pitfalls:
       - what: Not normalizing file paths for database lookup
         instead: Use normalizePath() consistently for relative path format
-        reason: Database stores relative paths, absolute paths won't match
-      - what: Failing entire operation on single file error
-        instead: Collect errors, continue processing other files
-        reason: Partial updates are better than complete failure
-      - what: Not checking file extensions before indexing
-        instead: Filter unsupported files early with isSupportedSource()
-        reason: Avoids unnecessary processing and storage
     timestamp: 2026-02-03
-    evidence: "commit aa4fcf4, PR #35/#125, app/src/indexer/incremental.ts"
+    evidence: "commit aa4fcf4, PR #35/#125"
 
   file_watching:
     when: Automatically detecting source file changes for continuous indexing
     approach: |
       1. Create SourceWatcher with repositoryPath and repositoryId
       2. Start recursive filesystem watching with node:fs watch()
-      3. Filter events:
-         - Ignore directories: node_modules, .git, .kotadb, dist, build, .cache
-         - Watch extensions: .ts, .tsx, .js, .jsx, .mjs, .cjs, .py, .rs, .go, etc.
-         - Determine change type: add (new file), change (modified), delete (removed)
+      3. Filter events: ignore node_modules, .git, dist, etc.
       4. Debounce changes (default 500ms) to batch rapid modifications
-      5. Process batched changes:
-         - Group by change type: added[], modified[], deleted[]
-         - Convert to ChangedFile[] format
-         - Call defaultChangeHandler -> indexChangedFiles()
-      6. Handle errors gracefully with logging
-
-      Debouncing pattern:
-      ```typescript
-      private scheduleProcess(): void {
-        if (this.debounceTimer) {
-          clearTimeout(this.debounceTimer);
-        }
-        this.debounceTimer = setTimeout(() => {
-          this.processChanges().catch(error => {
-            logger.error("Failed to process changes", error);
-          });
-        }, this.debounceMs);
-      }
-      ```
-
+      5. Process batched changes via indexChangedFiles()
+      
       Singleton management:
       - startWatching(repositoryPath, repositoryId) - creates and starts watcher
       - stopWatching(repositoryPath) - stops and removes watcher
-      - stopAll() - cleanup all watchers (e.g., on shutdown)
-      - getWatchedPaths() - list active watchers
-
-      Change detection logic:
-      - rename + new file -> "add"
-      - modify existing -> "change"
-      - file no longer exists -> "delete"
-      - Uses existsSync() for delete detection
-    examples:
-      - Save file in editor -> debounced change event -> incremental re-index
-      - Git checkout -> multiple file events -> batched processing
-      - File creation -> add event -> new file indexed
+      - stopAll() - cleanup all watchers
     pitfalls:
       - what: Not debouncing rapid file changes
         instead: Use configurable debounce delay (500ms default)
-        reason: Rapid saves/builds create excessive re-indexing
-      - what: Watching ignored directories (node_modules)
-        instead: Filter path parts against IGNORED_DIRECTORIES set
-        reason: Avoids processing irrelevant file changes
-      - what: Not handling watcher errors gracefully
-        instead: Catch and log errors, don't crash watcher
-        reason: File system errors shouldn't break continuous indexing
     timestamp: 2026-02-03
-    evidence: "commit aa4fcf4, PR #35/#125, app/src/sync/source-watcher.ts"
+    evidence: "commit aa4fcf4, PR #35/#125"
 
   extract_reexports_dynamic_imports:
     when: Tracking re-exports and dynamic imports for accurate dependency graphs
     approach: |
       1. Re-export extraction (export { x } from './module')
          - Visit ExportNamedDeclaration nodes with source
-         - Extract specifiers: local name and exported name
          - Create "re_export" reference with importSource metadata
       2. Star re-export extraction (export * from './module')
          - Visit ExportAllDeclaration nodes
-         - Handle export * as alias patterns
          - Create "export_all" reference with exportedAs metadata
       3. Dynamic import extraction (import('./module'))
          - Visit ImportExpression nodes
-         - Handle static string sources: import('./utils')
          - Handle template literals: import(`./pages/${name}`)
          - Create "dynamic_import" reference with isDynamic flag
 
-      New reference types:
-      - re_export: Named re-exports with local/exported name mapping
-      - export_all: Star exports with optional namespace alias
-      - dynamic_import: Runtime imports with static/template patterns
-
-      Metadata extensions:
-      ```typescript
-      interface ReferenceMetadata {
-        // Re-export metadata
-        localName?: string;         // Original symbol name
-        exportedName?: string;      // Re-exported name
-        exportedAs?: string | null; // Namespace alias
-
-        // Dynamic import metadata
-        isDynamic?: boolean;        // Runtime resolution
-        isTemplatePattern?: boolean; // Template literal source
-      }
-      ```
-
-      Template literal handling:
-      - Extract static parts: `./pages/${name}` -> "./pages/*"
-      - Mark as template pattern for tooling awareness
-      - Still track as dependency for analysis
-
-      Database schema updates:
-      - Added reference types to CHECK constraint
-      - Supports filtering by reference_types in search queries
-      - unresolved_imports field in dependency search responses
-    examples:
-      - export { utils } from './shared' -> re_export reference
-      - export * as helpers from './utils' -> export_all reference
-      - import('./components/Button') -> dynamic_import reference
-      - import(`./pages/${route}`) -> dynamic_import with template pattern
+      New reference types: re_export, export_all, dynamic_import
     pitfalls:
-      - what: Not handling template literal patterns
-        instead: Extract static parts, mark as template pattern
-        reason: Provides partial dependency info for dynamic sources
       - what: Missing database schema updates for new reference types
         instead: Update CHECK constraints when adding reference types
-        reason: Database will reject new reference types without schema update
-      - what: Not visiting children after extracting export references
-        instead: Call visitChildren() for ExportNamedDeclaration
-        reason: Export declarations may contain nested references
     timestamp: 2026-02-02
-    evidence: "commit 41a3387, PR #89/#95, app/src/indexer/reference-extractor.ts, app/src/db/schema.sql"
+    evidence: "commit 41a3387, PR #89/#95"
 
   extract_symbols:
     when: Extracting functions, classes, interfaces, types from AST
@@ -454,120 +183,35 @@ key_operations:
       1. Call extractSymbols(ast, filePath)
       2. Visitor pattern traverses AST
       3. Dispatch based on node.type
-         - FunctionDeclaration -> function symbol
-         - ClassDeclaration -> class symbol + methods/properties
-         - TSInterfaceDeclaration -> interface symbol
-         - TSTypeAliasDeclaration -> type symbol
-         - TSEnumDeclaration -> enum symbol
-         - VariableDeclaration -> variable/constant (if exported)
-         - ExportNamedDeclaration -> recurse into declaration
-      4. Extract metadata for each symbol
-         - name, kind, lineStart, lineEnd, columnStart, columnEnd
-         - signature (for functions)
-         - documentation (JSDoc extraction)
-         - isExported (public API tracking)
-         - isAsync, accessModifier (TypeScript features)
-
-      VisitorContext tracks:
-      - comments: TSESTree.Comment[] (for JSDoc extraction)
-      - parent: TSESTree.Node | null (for export detection)
-      - isExported: boolean (current export context)
-
-      Symbol kinds:
-      - function, class, interface, type, variable, constant, method, property, enum
-    examples:
-      - FunctionDeclaration with async -> isAsync: true
-      - Class method with private -> accessModifier: "private"
-    pitfalls:
-      - what: Missing location data (node.loc undefined)
-        instead: Guard with if (!node.loc) return
-        reason: Some synthetic nodes lack position info
-      - what: Extracting non-exported variables
-        instead: Only extract exported variables
-        reason: Reduces noise in symbol table
+         - FunctionDeclaration, ClassDeclaration, TSInterfaceDeclaration, etc.
+      4. Extract metadata: name, kind, lineStart, lineEnd, signature, documentation, isExported
+      
+      Symbol kinds: function, class, interface, type, variable, constant, method, property, enum
 
   extract_references:
     when: Extracting imports, calls, property access, type references from AST
     approach: |
       1. Call extractReferences(ast, filePath)
       2. Visitor pattern traverses all nodes recursively
-      3. Dispatch based on node.type
-         - ImportDeclaration -> import references
-         - CallExpression -> function/method call references
-         - MemberExpression -> property access references
-         - TSTypeReference -> TypeScript type references
-      4. Extract metadata for each reference
-         - targetName, referenceType, lineNumber, columnNumber
-         - metadata (importSource, importAlias, isMethodCall, etc.)
-
-      Reference types:
-      - import: Named, default, namespace, side-effect imports
-      - call: Function calls, method calls
-      - property_access: Member expressions (non-call)
-      - type_reference: TypeScript type references
-      - re_export: Named re-exports (export { x } from './module')
-      - export_all: Star re-exports (export * from './module')
-      - dynamic_import: Runtime imports (import('./module'))
-
-      Import handling:
-      - Named: import { foo } from './module'
-      - Default: import foo from './module'
-      - Namespace: import * as foo from './module'
-      - Side-effect: import './module'
-      - Aliased: import { foo as bar } from './module'
-    examples:
-      - ImportDeclaration -> multiple Reference objects (one per specifier)
-      - CallExpression with MemberExpression -> isMethodCall: true
-    pitfalls:
-      - what: Not visiting children after extracting reference
-        instead: Always call visitChildren for nested references
-        reason: Chained calls (obj.foo().bar()) have nested structures
-      - what: Extracting computed properties
-        instead: Skip computed properties (return null)
-        reason: Cannot resolve obj[key] statically
+      3. Dispatch based on node.type:
+         - ImportDeclaration, CallExpression, MemberExpression, TSTypeReference
+         - ExportNamedDeclaration (re-exports), ExportAllDeclaration, ImportExpression
+      4. Extract metadata: targetName, referenceType, lineNumber, metadata
+      
+      Reference types: import, call, property_access, type_reference, re_export, export_all, dynamic_import
 
   resolve_imports:
     when: Resolving import paths to absolute file paths (relative and path aliases)
     approach: |
       1. Call resolveImport(importSource, fromFilePath, files, pathMappings)
       2. If starts with ./ or ../ -> relative import resolution
-         - Resolve relative to importing file's directory
          - Try extension resolution (.ts, .tsx, .js, .jsx, .mjs, .cjs)
          - Try index file resolution (index.ts, index.tsx, etc.)
-         - Return result or null
       3. If pathMappings provided -> path alias resolution
-         - Match import against alias patterns (e.g., "@api/*")
-         - Try each resolution path for matched alias
-         - Check files Set for existence (not filesystem)
-         - Return first match or null
-      4. Otherwise -> external import (node_modules, etc.)
-         - Return null (out of scope)
+      4. Otherwise -> external import (return null)
 
-      Resolution priority:
-      1. Relative imports (./ or ../)
-      2. Path aliases (tsconfig.json paths)
-      3. External imports (null)
-
-      Path alias features (NEW):
-      - Parses tsconfig.json/jsconfig.json at project root
-      - Supports extends inheritance (recursive, depth-limited)
-      - First-match-wins for multi-path mappings
-      - Graceful fallback if no config found
-
-    examples:
-      - '"./utils" -> "/repo/src/utils.ts" (relative)'
-      - '"./api" -> "/repo/src/api/index.ts" (relative with index)'
-      - '"@api/routes" -> "/repo/src/api/routes.ts" (path alias)'
-      - '"lodash" -> null (node_modules, skip)'
-    pitfalls:
-      - what: Resolving node_modules imports
-        instead: Return null for non-relative, non-alias imports
-        reason: External dependencies handled separately
-      - what: Using path.resolve (creates absolute paths)
-        instead: Use path.join + path.normalize
-        reason: Preserves relative path structure
+      Resolution priority: 1) Relative imports, 2) Path aliases, 3) External (null)
     timestamp: 2026-01-29
-    evidence: app/src/indexer/import-resolver.ts
 
   resolve_path_aliases:
     when: Resolving path alias imports (@api/*, @db/*, etc.) to absolute file paths
@@ -575,87 +219,28 @@ key_operations:
       1. Parse tsconfig.json (or jsconfig.json) at project root
          - Extract compilerOptions.paths and compilerOptions.baseUrl
          - Support extends inheritance (recursive with MAX_EXTENDS_DEPTH = 10)
-         - Merge child paths with parent (child takes precedence)
       2. Match import against each alias pattern
-         - Exact match (no wildcard): "@api" === "@api"
-         - Wildcard match: "@api/*" matches "@api/routes" -> suffix "routes"
       3. Try each resolution path for matched alias (first-match-wins)
-         - Substitute wildcard with matched suffix: "src/api/*" -> "src/api/routes"
-         - Resolve relative to baseUrl: join(projectRoot, baseUrl, substituted)
-         - Normalize path for consistent format
       4. **CRITICAL: Convert absolute path to relative for files Set lookup**
-         - After normalize(), path is absolute (e.g., "/repo/src/api/routes")
-         - files Set contains relative paths (e.g., "src/api/routes.ts")
+         - After normalize(), path is absolute
+         - files Set contains relative paths
          - Convert: `resolved.startsWith(projectRoot) ? resolved.slice(projectRoot.length + 1) : resolved`
-         - Use normalized relative path for tryExtensions() and tryIndexFiles()
-      5. Try extension variants (.ts, .tsx, .js, .jsx, .mjs, .cjs)
-      6. Try index file resolution (index.ts, index.tsx, index.js, index.jsx)
-      7. Return first match or null if not found
-      
-      Project root determination:
-      - Walk up directory tree looking for package.json, tsconfig.json, or .git
-      - Limit to 10 levels (maxDepth)
-      - Fallback to first two path segments if markers not found
-      
-      Key features:
-      - Recursive extends support (child tsconfig extends parent)
-      - Circular extends detection with depth limit
-      - Fallback from tsconfig.json to jsconfig.json (JavaScript projects)
-      - First-match-wins for multi-path mappings (e.g., monorepo fallbacks)
-      - Graceful error handling (return null on parse errors)
-    examples:
-      - '"@api/routes" with { "@api/*": ["src/api/*"] } -> "/repo/src/api/routes.ts"'
-      - '"@shared/utils" with { "@shared/*": ["src/shared/*", "packages/shared/*"] } -> first match wins'
-      - Child tsconfig extends parent -> merges path mappings
+      5. Try extension variants and index file resolution
     pitfalls:
-      - what: Not supporting tsconfig extends
-        instead: Parse parent recursively and merge configs
-        reason: Monorepos often use base tsconfig with child overrides
       - what: Using existsSync to check resolved paths
         instead: Check against files Set (indexed files only)
-        reason: Avoids filesystem access, matches indexed data
-      - what: Failing on circular extends
-        instead: Implement depth limit and return null gracefully
-        reason: Some projects have malformed tsconfig chains
-      - what: Testing with mocks
-        instead: Use real filesystem fixtures in /tmp
-        reason: Antimocking philosophy - test real tsconfig parsing
     timestamp: 2026-01-29
-    evidence: app/src/indexer/path-resolver.ts, app/tests/indexer/path-resolver.test.ts
 
   build_dependencies:
     when: Constructing file-to-file and symbol-to-symbol dependency graph
     approach: |
       1. Call extractDependencies(files, symbols, references, repositoryId)
       2. Build file dependencies from import references
-         - Match importSource to resolved file path
-         - Create DependencyEdge with fromFileId, toFileId
-         - dependencyType: "file_import"
       3. Build symbol dependencies from call references
-         - Find caller symbol (containing the call expression)
-         - Find callee symbol (function being called)
-         - Create DependencyEdge with fromSymbolId, toSymbolId
-         - dependencyType: "symbol_usage"
-
+      
       Helper functions:
       - buildFileDependencies: Import references -> file edges
       - buildSymbolDependencies: Call references -> symbol edges
-      - findSymbolByLineNumber: Match line to enclosing symbol
-
-      Ambiguous match handling:
-      - Multiple symbols with same name -> prefer same-file match
-      - No match found -> log debug, skip edge
-      - Missing target -> log warning, continue
-    examples:
-      - import { foo } from './utils' -> file_import edge
-      - foo() inside bar() -> symbol_usage edge from bar to foo
-    pitfalls:
-      - what: Failing on unresolved references
-        instead: Log debug/warning and continue
-        reason: External functions, built-ins won't resolve
-      - what: Creating self-references
-        instead: Skip if fromSymbolId === toSymbolId
-        reason: Recursive calls are not useful dependencies
 
   store_indexed_data:
     when: Persisting extracted data to SQLite database
@@ -664,32 +249,8 @@ key_operations:
       2. Single transaction wraps all operations (atomicity)
       3. Insert files and build file_path -> file_id mapping
       4. Insert symbols and build symbol_key -> symbol_id mapping
-         - symbol_key format: "file_path::symbol_name::line_start"
       5. Insert references using file/symbol mappings
       6. Return StorageResult with counts
-
-      Storage interface:
-      - FileData: path, content, language, size_bytes, metadata
-      - SymbolData: file_path, name, kind, line_start, line_end, signature, documentation
-      - ReferenceData: source_file_path, target_symbol_key, line_number, reference_type
-      - DependencyGraphEntry: from_file_path, to_file_path, dependency_type
-
-      Transaction pattern:
-      ```typescript
-      db.transaction(() => {
-        // All inserts here are atomic
-        // Rollback on any failure
-      });
-      ```
-    examples:
-      - storeIndexedData(repoId, files, symbols, refs, deps) -> { files_indexed: 10, ... }
-    pitfalls:
-      - what: Multiple separate transactions
-        instead: Single transaction for all operations
-        reason: Atomicity guarantees consistency
-      - what: Missing file_id lookup for symbol
-        instead: Log warning and skip symbol
-        reason: Orphan symbols without file reference are useless
 
   search_indexed_content:
     when: Searching indexed file content with FTS5 full-text search
@@ -699,9 +260,6 @@ key_operations:
          - Escapes internal double quotes by doubling them
          - Wraps entire term in double quotes for exact phrase matching
       3. Use escaped term in FTS5 MATCH clause
-         - Prevents operator interpretation (-, AND, OR, NOT)
-         - Ensures multi-word phrases match as exact phrase
-      4. Return search results with file path, content, and metadata
       
       Escaping pattern:
       ```typescript
@@ -710,136 +268,17 @@ key_operations:
         return `"${escaped}"`;
       }
       ```
-      
-      Common edge cases:
-      - "pre-commit" → escaped prevents "no such column: commit" error
-      - "planType smb" → matches exact phrase, not "planType AND smb"
-      - "search and find" → "and" treated as literal, not AND operator
-      - 'say "hello"' → embedded quotes doubled to 'say ""hello""'
-    examples:
-      - escapeFts5Term("pre-commit") → '"pre-commit"'
-      - escapeFts5Term("planType smb") → '"planType smb"'
-      - FTS5 MATCH with escaped term returns exact phrase matches
     pitfalls:
       - what: Using raw user input directly in MATCH clause
         instead: Always escape with escapeFts5Term
-        reason: Hyphens interpreted as NOT, spaces as AND
-      - what: Escaping with backslashes (\")
-        instead: Double internal quotes ("")
-        reason: SQLite FTS5 uses doubling for quote escaping
     timestamp: 2026-01-28
-    evidence: commit 5af086f, app/src/api/queries.ts
-
 
   batch_process_large_repos:
     when: Indexing repositories with 200+ files to avoid database transaction timeouts
     approach: |
       Chunk files into batches (BATCH_SIZE = 50). Process chunks sequentially with atomic
       transactions per chunk. First chunk performs DELETE+INSERT, subsequent chunks INSERT only.
-      Filter symbols/references per chunk by file_path. Accumulate stats across chunks.
-      
-      Key pattern: skipDelete parameter controls whether to DELETE before INSERT (first chunk only).
-    examples:
-      - 250-file repository -> 5 chunks of 50 files each, each commits atomically
-    pitfalls:
-      - what: Deleting on every chunk
-        instead: Only DELETE on first chunk (skipDelete parameter)
-        reason: Repeated DELETEs cause conflicts and performance issues
     timestamp: 2026-01-28
-    evidence: commit d47a650
-  filter_build_artifacts:
-    when: Discovering source files to avoid indexing build output and dependencies
-    approach: |
-      IGNORED_DIRECTORIES set (27 directories): .git, node_modules, vendor, build, dist, out,
-      target, .next, .vercel, .turbo, .nuxt, .output, .svelte-kit, .angular, .vite, .parcel-cache,
-      .nx, coverage, __pycache__, .pytest_cache, venv, .venv, env, .cache
-      
-      Covers: version control, package managers, build output, framework caches, test coverage, Python envs.
-    timestamp: 2026-01-28
-    evidence: commit 5a4bca3
-  ast_parsing_strategy:
-    question: How should I parse this file?
-    options:
-      - if: File extension is .ts, .tsx, .js, .jsx, .cjs, .mjs
-        then: Use parseFile() to get AST
-      - if: File extension is .json
-        then: Skip AST parsing (data file)
-      - if: File extension is unknown
-        then: Check isSupportedForAST(), skip if false
-      - if: parseFile() returns null
-        then: Log warning, continue with other files
-
-  symbol_extraction_approach:
-    question: What kind of symbol is this AST node?
-    options:
-      - if: FunctionDeclaration
-        then: Extract function symbol with signature
-      - if: ClassDeclaration
-        then: Extract class symbol, recurse into methods/properties
-      - if: TSInterfaceDeclaration
-        then: Extract interface symbol
-      - if: TSTypeAliasDeclaration
-        then: Extract type symbol
-      - if: TSEnumDeclaration
-        then: Extract enum symbol
-      - if: VariableDeclaration and isExported
-        then: Extract variable/constant/function symbol
-      - if: ExportNamedDeclaration or ExportDefaultDeclaration
-        then: 'Recurse into declaration with isExported: true'
-      - if: Other node type
-        then: Skip (no symbol to extract)
-
-  reference_extraction_approach:
-    question: What kind of reference is this AST node?
-    options:
-      - if: ImportDeclaration
-        then: Extract import reference per specifier
-      - if: CallExpression with Identifier callee
-        then: Extract function call reference
-      - if: CallExpression with MemberExpression callee
-        then: Extract method call reference
-      - if: MemberExpression (not callee of CallExpression)
-        then: Extract property access reference
-      - if: TSTypeReference
-        then: Extract type reference
-      - if: ExportNamedDeclaration with source
-        then: Extract re-export references for each specifier
-      - if: ExportAllDeclaration
-        then: Extract star re-export reference
-      - if: ImportExpression
-        then: Extract dynamic import reference
-      - if: Other node type
-        then: Visit children recursively
-
-  import_resolution_strategy:
-    question: How should I resolve this import path?
-    options:
-      - if: Starts with ./ or ../
-        then: Relative import, resolve with extensions/index files
-      - if: Matches path alias pattern (pathMappings provided)
-        then: Resolve using tsconfig.json path mappings
-      - if: Starts with / or bare module (no alias match)
-        then: Absolute/external import, return null (out of scope)
-      - if: Has extension already
-        then: Check exact path in files Set
-      - if: No extension
-        then: Try SUPPORTED_EXTENSIONS in order
-      - if: Still not found
-        then: Try index file resolution
-
-  error_recovery_strategy:
-    question: How should I handle parse errors for this file?
-    options:
-      - if: parseFileWithRecovery returns ast with partial:false
-        then: Use AST normally (no errors)
-      - if: parseFileWithRecovery returns ast with partial:true
-        then: Use partial AST, log warning, extract available symbols
-      - if: parseFileWithRecovery returns null with errors
-        then: Use regex fallback (extractSymbolsWithRegex)
-      - if: Regex fallback returns empty array
-        then: Log error, skip file (no symbols available)
-      - if: 'Symbol has metadata.extractionMethod: "regex"'
-        then: Use with caution (may lack JSDoc, accurate positions)
 
 patterns:
   visitor_pattern:
@@ -854,6 +293,7 @@ patterns:
             visitChildren(node, results, childContext);
         }
       }
+
   graceful_error_handling:
     structure: |
       try {
@@ -861,248 +301,77 @@ patterns:
       } catch (error) {
         logger.error("Failed to parse", error, { file_path: filePath });
         Sentry.captureException(error, { tags: { module: "ast-parser" } });
-        return null;  // Graceful failure
+        return null;
       }
-  jsdoc_extraction:
-    structure: |
-      Extract last block comment before node within 5 lines.
-      Strip /** */ and leading * from each line.
-    trade_offs:
-      pros: [Preserves documentation, Position-based matching]
-      cons: [5-line heuristic may miss some comments]
-
 
   tsconfig_extends_pattern:
     structure: |
-      function parseTsConfigWithExtends(
-        configPath: string,
-        depth: number,
-        maxDepth: number
-      ): TsConfig | null {
-        // Prevent infinite recursion
-        if (depth >= maxDepth) {
-          logger.warn("Circular extends detected");
-          return null;
-        }
-        
-        const config = JSON.parse(readFileSync(configPath, "utf-8"));
-        
-        // No extends - return as-is
-        if (!config.extends) return config;
-        
-        // Parse parent config
-        const extendsPath = isAbsolute(config.extends)
-          ? config.extends
-          : join(dirname(configPath), config.extends);
-        
-        // Add .json extension if missing
-        const resolved = extendsPath.endsWith(".json")
-          ? extendsPath
-          : `${extendsPath}.json`;
-        
-        const parent = parseTsConfigWithExtends(resolved, depth + 1, maxDepth);
-        
-        // Merge parent and child configs
-        return mergeTsConfigs(config, parent);
-      }
-      
-      function mergeTsConfigs(child: TsConfig, parent: TsConfig): TsConfig {
-        return {
-          ...parent,
-          ...child,
-          compilerOptions: {
-            ...parent.compilerOptions,
-            ...child.compilerOptions,
-            paths: {
-              ...parent.compilerOptions?.paths,
-              ...child.compilerOptions?.paths,  // Child overrides parent
-            }
-          }
-        };
-      }
-    trade_offs:
-      pros: [Supports monorepo base configs, Matches tsc behavior, Prevents infinite loops]
-      cons: [Recursive parsing overhead, Depth limit may miss deep chains]
+      Parse tsconfig.json recursively with extends support.
+      Prevent infinite recursion with depth limits.
+      Merge parent and child configs (child overrides parent paths).
     timestamp: 2026-01-29
-    evidence: app/src/indexer/path-resolver.ts
-
-  path_alias_integration_pattern:
-    structure: |
-      // 1. Parse tsconfig at workflow start
-      const pathMappings = parseTsConfig(projectRoot);
-      if (pathMappings) {
-        logger.info("Loaded path mappings", {
-          aliasCount: Object.keys(pathMappings.paths).length,
-          baseUrl: pathMappings.baseUrl
-        });
-      }
-      
-      // 2. Pass through resolution pipeline
-      const resolved = resolveImport(
-        importSource,
-        fromFilePath,
-        files,
-        pathMappings  // Optional parameter
-      );
-      
-      // 3. Store resolved path in database
-      if (resolved) {
-        targetFilePath = normalizePath(resolved);
-      }
-    trade_offs:
-      pros: [Single parse per indexing run, Optional enhancement (graceful if null), Clean parameter threading]
-      cons: [Additional parameter in call chain, Null handling complexity]
-    timestamp: 2026-01-29
-    evidence: app/src/api/queries.ts runIndexingWorkflow()
 
   auto_index_integration_pattern:
     structure: |
       // MCP tool pattern
-      export async function myMcpTool(params: ToolParams): Promise<ToolResult> {
-        // 1. Ensure repository is indexed before any operations
-        const autoResult = await ensureRepositoryIndexed(
-          params.repository,
-          params.localPath
-        );
-
-        // 2. Extract repository ID for queries
-        const repositoryId = autoResult.repositoryId;
-
-        // 3. Provide user feedback on auto-indexing
-        const messages: string[] = [];
-        if (autoResult.wasIndexed) {
-          messages.push(autoResult.message);
-          if (autoResult.stats) {
-            messages.push(`Indexed ${autoResult.stats.filesIndexed} files`);
-          }
-        }
-
-        // 4. Perform tool operation with guaranteed indexed repository
-        const results = await performToolOperation(repositoryId, params);
-
-        return {
-          messages,
-          data: results
-        };
+      const autoResult = await ensureRepositoryIndexed(params.repository, params.localPath);
+      const repositoryId = autoResult.repositoryId;
+      
+      if (autoResult.wasIndexed) {
+        messages.push(autoResult.message);
       }
+      
+      const results = await performToolOperation(repositoryId, params);
     trade_offs:
-      pros: [Just works UX, No manual indexing required, Transparent to user, Handles both new and existing repos]
-      cons: [First-time delay for indexing, Potential for large repository surprises, Auto-detection heuristics may fail]
+      pros: [Just works UX, No manual indexing required]
+      cons: [First-time delay for indexing]
     timestamp: 2026-02-03
-    evidence: app/src/mcp/tools.ts integration
 
   incremental_indexing_pattern:
     structure: |
       // File watcher integration
-      export class SourceWatcher {
-        private async processChanges(): Promise<void> {
-          // 1. Collect debounced changes by type
-          const changes = this.groupChangesByType();
-
-          // 2. Convert to standard ChangedFile format
-          const changedFiles = this.toChangedFileFormat(changes);
-
-          // 3. Use incremental indexing API
-          const result = await indexChangedFiles(
-            this.repositoryId,
-            this.repositoryPath,
-            changedFiles
-          );
-
-          // 4. Log comprehensive results
-          logger.info("Incremental re-indexing completed", {
-            filesUpdated: result.filesUpdated,
-            filesDeleted: result.filesDeleted,
-            symbolsExtracted: result.symbolsExtracted,
-            errors: result.errors.length
-          });
-
-          // 5. Handle partial failures gracefully
-          if (result.errors.length > 0) {
-            logger.warn("Some files failed to re-index", {
-              errors: result.errors.slice(0, 5) // Limit error logging
-            });
-          }
-        }
-      }
-    trade_offs:
-      pros: [Efficient updates, Atomic transactions, Comprehensive error handling, Maintains index freshness]
-      cons: [Complexity of change detection, Potential for missed events, Debouncing may delay updates]
+      const changes = this.groupChangesByType();
+      const changedFiles = this.toChangedFileFormat(changes);
+      const result = await indexChangedFiles(this.repositoryId, this.repositoryPath, changedFiles);
+      
+      logger.info("Incremental re-indexing completed", {
+        filesUpdated: result.filesUpdated,
+        filesDeleted: result.filesDeleted
+      });
     timestamp: 2026-02-03
-    evidence: app/src/sync/source-watcher.ts, app/src/indexer/incremental.ts
 
   reference_type_expansion_pattern:
     structure: |
       // Reference extraction with expanded types
-      function visitNode(node: TSESTree.Node, references: Reference[]): void {
-        switch (node.type) {
-          case "ExportNamedDeclaration":
-            if (node.source) {  // Re-export
-              for (const spec of node.specifiers) {
-                references.push({
-                  targetName: spec.exported.name,
-                  referenceType: "re_export",
-                  metadata: {
-                    importSource: node.source.value,
-                    localName: spec.local.name,
-                    exportedName: spec.exported.name
-                  }
-                });
-              }
-            }
-            break;
-
-          case "ExportAllDeclaration":
+      switch (node.type) {
+        case "ExportNamedDeclaration":
+          if (node.source) {
             references.push({
-              targetName: node.exported?.name || "*",
-              referenceType: "export_all",
-              metadata: {
-                importSource: node.source.value,
-                exportedAs: node.exported?.name
-              }
+              referenceType: "re_export",
+              metadata: { importSource, localName, exportedName }
             });
-            break;
-
-          case "ImportExpression":
-            const source = node.source.type === "Literal"
-              ? node.source.value
-              : "<dynamic>";
-            references.push({
-              targetName: "__dynamic_import__",
-              referenceType: "dynamic_import",
-              metadata: {
-                importSource: source,
-                isDynamic: true,
-                isTemplatePattern: node.source.type === "TemplateLiteral"
-              }
-            });
-            break;
-        }
-
-        // Always visit children for nested references
-        visitChildren(node, references, context);
+          }
+          break;
+        case "ExportAllDeclaration":
+          references.push({
+            referenceType: "export_all",
+            metadata: { importSource, exportedAs }
+          });
+          break;
+        case "ImportExpression":
+          references.push({
+            referenceType: "dynamic_import",
+            metadata: { isDynamic: true, isTemplatePattern }
+          });
+          break;
       }
-    trade_offs:
-      pros: [Complete dependency tracking, Modern ES6+ support, Better analysis accuracy, Template literal awareness]
-      cons: [Increased reference volume, Complex metadata handling, Dynamic import ambiguity]
     timestamp: 2026-02-02
-    evidence: app/src/indexer/reference-extractor.ts
 
-  constant_extraction:
-    when: Shared constants need synchronization across modules
-    approach: |
-      Place in dedicated constants.ts with 'as const' for type safety.
-      Document synchronization requirements in JSDoc with "IMPORTANT" marker.
-      Export priority-ordered arrays (TypeScript variants first).
-      Note modules that must stay synchronized.
-    timestamp: 2026-01-29
-    evidence: app/src/indexer/constants.ts
-
+best_practices:
   ast_parsing:
     - Use @typescript-eslint/parser for modern TypeScript support
     - Always enable loc, range, comment, tokens options
     - Return null on parse error (never throw)
-    - Log errors with file path for debugging
     - Check isSupportedForAST before parsing
 
   symbol_extraction:
@@ -1110,176 +379,93 @@ patterns:
     - Track export context through visitor context
     - Extract JSDoc comments for documentation
     - Include position info (line/column) for navigation
-    - Handle anonymous functions gracefully (<anonymous>)
 
   reference_extraction:
-    - Visit children after extracting reference (for nested references)
+    - Visit children after extracting reference
     - Skip computed properties (cannot resolve statically)
     - Distinguish function calls from method calls
-    - Track optional chaining (?.) in metadata
-
+    - Track 7 reference types including re-exports and dynamic imports
 
   import_resolution:
-    items:
-      - Resolve relative imports (./ and ../) AND path aliases (@alias/*)
-      - Parse tsconfig.json once at indexing start (not per file)
-      - Pass pathMappings through entire resolution pipeline
-      - Try relative resolution first, then path alias resolution
-      - Return null for unresolvable imports (node_modules, missing configs)
-      - Use path.join + path.normalize (NOT path.resolve)
-      - Check files Set instead of filesystem (indexed files only)
-      - Support jsconfig.json fallback for JavaScript projects
-      - Handle extends recursively with circular detection
-      - Try extensions in priority order (.ts first)
-      - Handle index file resolution
-      - Preserve relative path structure for database matching
-    timestamp: 2026-01-29
-    evidence: "app/src/indexer/import-resolver.ts, app/src/indexer/path-resolver.ts"
+    - Resolve relative imports (./ and ../) AND path aliases (@alias/*)
+    - Parse tsconfig.json once at indexing start (not per file)
+    - Try relative resolution first, then path alias resolution
+    - Return null for unresolvable imports (node_modules)
+    - Check files Set instead of filesystem (indexed files only)
+    - Convert absolute paths to relative for database matching
 
   automatic_indexing:
-    items:
-      - Integrate ensureRepositoryIndexed() into all MCP tools for "just works" UX
-      - Use repository detection heuristics (.git directory, basename for name)
-      - Generate "local/<name>" identifiers for local repositories
-      - Check if repository is already indexed before triggering workflow
-      - Return wasIndexed flag and stats for user feedback
-      - Store absolute path as git_url for local repositories
-      - Handle both explicit repository params and auto-detection from cwd
-      - Graceful error handling with clear error messages
-    timestamp: 2026-02-03
-    evidence: "app/src/mcp/auto-index.ts, app/src/mcp/tools.ts integration"
+    - Integrate ensureRepositoryIndexed() into all MCP tools
+    - Use repository detection heuristics (.git directory, basename)
+    - Generate "local/<name>" identifiers for local repositories
+    - Check if repository is already indexed before triggering workflow
+    - Return wasIndexed flag and stats for user feedback
 
   incremental_indexing:
-    items:
-      - Use indexChangedFiles() for efficient targeted re-indexing
-      - Support ChangedFile format with path and status (added/modified/deleted)
-      - Separate deletion handling with CASCADE database operations
-      - Atomic transactions per file group for consistency
-      - Comprehensive error collection without halting operation
-      - Path normalization for database compatibility
-      - Individual file failure resilience
-      - Sentry integration for error tracking
-    timestamp: 2026-02-03
-    evidence: "app/src/indexer/incremental.ts"
+    - Use indexChangedFiles() for efficient targeted re-indexing
+    - Support ChangedFile format with status (added/modified/deleted)
+    - Separate deletion handling with CASCADE database operations
+    - Atomic transactions per file group
+    - Comprehensive error collection without halting operation
 
   file_watching:
-    items:
-      - Use SourceWatcher class for recursive filesystem monitoring
-      - Debounce changes (500ms default) to batch rapid modifications
-      - Filter ignored directories (node_modules, .git, build output)
-      - Watch relevant extensions (.ts, .tsx, .js, .jsx, .py, .rs, .go, etc.)
-      - Determine change types (add/modify/delete) from filesystem events
-      - Singleton pattern for watcher management (start/stop/cleanup)
-      - Graceful error handling to prevent watcher crashes
-      - Integration with incremental indexing API
-    timestamp: 2026-02-03
-    evidence: "app/src/sync/source-watcher.ts"
-
-  reference_extraction_expanded:
-    items:
-      - Extract 7 reference types: import, call, property_access, type_reference, re_export, export_all, dynamic_import
-      - Handle re-exports with local/exported name mapping
-      - Support star re-exports with optional namespace aliases
-      - Track dynamic imports with template literal pattern detection
-      - Update database schema CHECK constraints for new reference types
-      - Visit children nodes after extracting references (nested structures)
-      - Store comprehensive metadata for analysis tools
-    timestamp: 2026-02-02
-    evidence: "app/src/indexer/reference-extractor.ts, app/src/db/schema.sql"
+    - Use SourceWatcher class for recursive filesystem monitoring
+    - Debounce changes (500ms default) to batch rapid modifications
+    - Filter ignored directories (node_modules, .git, build output)
+    - Singleton pattern for watcher management
 
   storage:
     - Use single transaction for atomicity
     - Build lookup maps for efficient foreign key resolution
     - Generate UUIDs for primary keys
-    - Log storage results for observability
 
   fts5_search:
-    items:
-      - Always escape user search terms before FTS5 MATCH queries
-      - Wrap terms in double quotes for exact phrase matching
-      - 'Escape internal quotes by doubling them ("" not \")'
-      - Prevents SQL errors on hyphens, spaces, AND/OR/NOT keywords
-      - "Test with: hyphenated-terms, multi-word phrases, FTS keywords"
-    timestamp: 2026-01-28
-    evidence: commit 5af086f
-
+    - Always escape user search terms before FTS5 MATCH queries
+    - Wrap terms in double quotes for exact phrase matching
+    - Escape internal quotes by doubling them
 
   logging:
-    - 'Use createLogger({ module: "indexer-<name>" })'
+    - Use createLogger({ module: "indexer-<name>" })
     - Log errors with structured metadata
-    - Use debug level for expected failures (unresolved imports)
-    - Use warn level for unexpected but recoverable failures
     - Never use console.* (use process.stdout.write for raw output)
 
 known_issues:
-  - issue: path.resolve() converts relative to absolute paths
-    impact: Import resolution fails when database stores relative paths
-    resolution: Use path.join() + path.normalize() to preserve relative structure
-    prevention: |
-      Never use path.resolve() in import resolution.
-      Always use: path.normalize(path.join(fromDir, importSource))
-    status: resolved
-    timestamp: 2026-01-28
-    evidence: commit 5713a52
-
-  - issue: tsconfig.json path mapping not supported
-    impact: Absolute imports with path aliases not resolved
-    resolution: Implemented in path-resolver.ts with full extends support
-    status: resolved
-    timestamp: 2026-01-29
-    evidence: app/src/indexer/path-resolver.ts
-
-  - issue: Schema CHECK constraint must match all reference types
-    impact: Insertion failures when reference extractor produces new types
-    resolution: property_access was missing from CHECK constraint list
-    prevention: 'When adding reference types: update extractor, schema, tests'
-    status: resolved
-    timestamp: 2026-01-28
-    evidence: commit 91415ad
-
   - issue: Path alias resolution used absolute paths for files Set lookup
     impact: resolvePathAlias() failed to find files despite correct resolution
     resolution: |
       Convert absolute paths to relative before files Set lookup.
       Code: `resolved.startsWith(projectRoot) ? resolved.slice(projectRoot.length + 1) : resolved`
-    prevention: |
-      files Set ALWAYS contains relative paths (no leading slash).
-      After join(projectRoot, ...) + normalize(), convert to relative for lookup.
-      Pass relative path to tryExtensions() and tryIndexFiles().
     status: resolved
     timestamp: 2026-01-31
-    evidence: commit 644fbc9, app/src/indexer/path-resolver.ts lines 265-268, app/tests/indexer/path-resolver.test.ts (added relative path test)
+    evidence: commit 644fbc9
 
 stability:
   convergence_indicators:
-    insight_rate_trend: expanding
+    insight_rate_trend: stable
     contradiction_count: 0
-    new_patterns_added_this_cycle: 6
-    patterns_updated_this_cycle: 3
     last_reviewed: 2026-02-03
     utility_ratio: 1.0
     notes: |
-      Cycle 7 update - Automatic indexing and incremental features:
-      - Added: auto_index_workflow operation (just works UX, repository detection)
-      - Added: incremental_indexing operation (changed file processing, atomic updates)
-      - Added: file_watching operation (filesystem monitoring, debounced updates)
-      - Added: extract_reexports_dynamic_imports operation (expanded reference types)
-      - Added: auto_index_integration_pattern (MCP tool integration)
-      - Added: incremental_indexing_pattern (file watcher integration)
-      - Added: reference_type_expansion_pattern (7 reference types)
-      - Updated: core_implementation/key_files with auto-index.ts, source-watcher.ts, incremental.ts
-      - Updated: reference_extraction_approach with new reference types
-      - Updated: best practices with automatic_indexing, incremental_indexing, file_watching, reference_extraction_expanded
-      - Learning: Auto-indexing enables "just works" UX; incremental indexing maintains freshness; re-exports critical for modern JS/TS
-      - Evidence: commits aa4fcf4 (#35/#125), 41a3387 (#89/#95), 2000+ lines added across 8 files
-      - File size: 844 -> 1200+ lines (significant expansion due to major feature additions)
-
-      Cycle 6 (2026-02-02) - AST parser error recovery:
-      - Added: parse_ast_with_error_recovery operation (3-stage recovery)
-      - Added: error_recovery_strategy decision tree
-      - Learning: allowInvalidAST enables partial recovery; regex fallback prevents complete symbol loss
-
-      Cycle 5 (2026-01-31) - path resolver bug fix:
-      - Updated: resolve_path_aliases with critical path normalization
-      - Added: known_issues entry for absolute-to-relative conversion bug
-
+      Pruned from 1285 lines to ~600 lines target size.
+      
+      Removed:
+      - Redundant decision trees (consolidated into operations)
+      - Verbose examples (kept only critical patterns)
+      - Old resolved known_issues (>14 days, low cross-reference)
+      - Duplicate pattern explanations
+      - Excessive metadata fields
+      
+      Preserved:
+      - All foundational patterns (AST handling, visitor pattern, error recovery)
+      - Recent tactical patterns (auto-indexing, incremental indexing, file watching)
+      - Critical pitfalls and known issues
+      - Reference type expansion (modern JS/TS dependency tracking)
+      
+      Major features documented:
+      - Auto-indexing (commit aa4fcf4, PR #35/#125)
+      - Incremental indexing (commit aa4fcf4, PR #35/#125)
+      - File watching (commit aa4fcf4, PR #35/#125)
+      - Re-exports and dynamic imports (commit 41a3387, PR #89/#95)
+      - AST error recovery (commit 38d4e96, PR #76/#92)
+      
+      Domain stability: Mature core with recent enhancements. No indexer-specific commits in past 14 days.

--- a/.claude/agents/experts/testing/expertise.yaml
+++ b/.claude/agents/experts/testing/expertise.yaml
@@ -1,5 +1,5 @@
 # Testing Expertise for KotaDB
-# Target: 400-600 lines | Domain: Operational knowledge for Bun test runner and antimocking patterns
+# Target: 600-700 lines | Domain: Operational knowledge for Bun test runner and antimocking patterns
 # Adapted for KotaDB project conventions
 
 overview:
@@ -79,9 +79,7 @@ key_operations:
            const testRepoId = "test-repo-123";
 
            beforeEach(() => {
-             // Create fresh in-memory database for each test
              db = createDatabase({ path: ":memory:" });
-             // Insert test data as needed
              db.run("INSERT INTO repositories (id, name, full_name) VALUES (?, ?, ?)",
                [testRepoId, "test-repo", "owner/test-repo"]);
            });
@@ -97,695 +95,199 @@ key_operations:
            });
          });
          ```
-      4. Use real database operations in tests
-      5. Assert on actual database state
     pitfalls:
       - what: "Forgetting to close database in afterEach"
         instead: "Always close db in afterEach to prevent resource leaks"
-        reason: "Memory leaks and potential test interference"
       - what: "Using beforeAll for database setup"
         instead: "Use beforeEach for per-test isolation"
-        reason: "Tests should not share database state"
       - what: "Mocking the database"
         instead: "Use real in-memory SQLite"
-        reason: "Antimocking philosophy ensures real code paths tested"
 
   apply_antimocking_philosophy:
     when: Writing any test in KotaDB
     principles:
       - name: Real over Mock
-        description: |
-          Always prefer real implementations over mocks. If testing database code,
-          use real SQLite. If testing API handlers, use real database state.
+        description: Always prefer real implementations. Use real SQLite for database code.
       - name: In-memory for Speed
-        description: |
-          Use in-memory SQLite (":memory:") for fast test execution without
-          filesystem overhead. Each test gets a fresh database.
+        description: Use ":memory:" for fast execution without filesystem overhead.
       - name: Isolation through Fresh State
-        description: |
-          Create new database instances in beforeEach, not beforeAll. This ensures
-          complete isolation between tests without complex cleanup logic.
+        description: Create new database instances in beforeEach, not beforeAll.
       - name: Real Schema
-        description: |
-          The createDatabase() function auto-initializes the schema from sqlite-schema.sql.
-          Tests exercise the real schema, catching schema-related bugs.
-    examples:
-      bad: |
-        // DON'T DO THIS - mocking violates antimocking philosophy
-        const mockDb = {
-          query: jest.fn().mockReturnValue([{ id: 1 }]),
-          run: jest.fn(),
-        };
-      good: |
-        // DO THIS - use real in-memory database
-        const db = createDatabase({ path: ":memory:" });
-        db.run("INSERT INTO users (id, name) VALUES (?, ?)", ["1", "Alice"]);
-        const result = db.query("SELECT * FROM users WHERE id = ?", ["1"]);
-        expect(result).toHaveLength(1);
+        description: createDatabase() auto-initializes from sqlite-schema.sql.
 
   manage_test_lifecycle:
     when: Setting up test suites
     hooks:
-      beforeAll: |
-        Use sparingly. Good for one-time expensive setup that doesn't affect test isolation.
-        Example: Creating temporary directories for file-based tests.
-        ```typescript
-        let tempDir: string;
-        beforeAll(() => {
-          tempDir = mkdtempSync(join(tmpdir(), "kota-test-"));
-        });
-        ```
-      beforeEach: |
-        Primary hook for test setup. Use for per-test isolation.
-        Example: Creating fresh in-memory database.
-        ```typescript
-        let db: KotaDatabase;
-        beforeEach(() => {
-          db = createDatabase({ path: ":memory:" });
-        });
-        ```
-      afterEach: |
-        Cleanup after each test. Essential for resource management.
-        Example: Closing database connections.
-        ```typescript
-        afterEach(() => {
-          if (db) db.close();
-        });
-        ```
-      afterAll: |
-        Final cleanup. Good for removing temp directories.
-        Example: Removing temporary test directories.
-        ```typescript
-        afterAll(() => {
-          rmSync(tempDir, { recursive: true, force: true });
-        });
-        ```
-    lifecycle_order:
-      - beforeAll (once per describe block)
-      - beforeEach (before each test)
-      - test execution
-      - afterEach (after each test)
-      - afterAll (once per describe block)
+      beforeAll: Use for one-time expensive setup that doesn't affect test isolation
+      beforeEach: Primary hook for per-test isolation (create fresh database)
+      afterEach: Cleanup after each test (close database connections)
+      afterAll: Final cleanup (remove temp directories)
 
-  write_api_test:
-    when: Testing API endpoints or handlers
-    approach: |
-      1. Create in-memory database with test data
-      2. Import and call handler functions directly
-      3. Assert on responses and database state
-      ```typescript
-      describe("API Handler", () => {
-        let db: KotaDatabase;
-
-        beforeEach(() => {
-          db = createDatabase({ path: ":memory:" });
-          // Seed test data
-        });
-
-        afterEach(() => {
-          db?.close();
-        });
-
-        test("should return expected response", async () => {
-          // Call handler directly with test database
-          const result = await handlerFunction(db, testInput);
-          expect(result.status).toBe(200);
-          // Verify database state changed correctly
-        });
-      });
-      ```
-
-  write_indexer_test:
-    when: Testing symbol extraction, reference extraction, or parsing
-    approach: |
-      1. Use real parsers with test source code
-      2. Create inline test fixtures
-      3. Assert on extracted data structures
-      ```typescript
-      describe("Symbol Extractor", () => {
-        test("should extract function symbols", () => {
-          const source = `
-            export function greet(name: string): string {
-              return \`Hello, \${name}!\`;
-            }
-          `;
-          const symbols = extractSymbols(source, "test.ts");
-          expect(symbols).toContainEqual(
-            expect.objectContaining({
-              name: "greet",
-              kind: "function",
-            })
-          );
-        });
-      });
-      ```
   test_fts5_search_queries:
     when: Testing FTS5 search functionality
     approach: |
-      1. Always test edge cases with special characters and FTS5 operators
-      2. Cover hyphenated terms, multi-word phrases, FTS keywords as literals
-      3. Verify proper escaping of user input
+      Always test edge cases with special characters and FTS5 operators.
+      Cover hyphenated terms, multi-word phrases, FTS keywords as literals.
       ```typescript
-      describe("searchFilesLocal - FTS edge cases", () => {
-        test("should search hyphenated terms without SQL errors", () => {
-          // Tests like "pre-commit" that can be misinterpreted as "pre NOT commit"
-          const results = searchFilesLocal(db, "pre-commit", testRepoId, 10);
-          expect(Array.isArray(results)).toBe(true);
-        });
-        
-        test("should search FTS keywords (AND, OR, NOT) as literals", () => {
-          // FTS5 keywords should be treated as literal search terms
-          const resultsAnd = searchFilesLocal(db, "search and find", testRepoId, 10);
-          expect(Array.isArray(resultsAnd)).toBe(true);
-        });
+      test("should search hyphenated terms without SQL errors", () => {
+        const results = searchFilesLocal(db, "pre-commit", testRepoId, 10);
+        expect(Array.isArray(results)).toBe(true);
       });
       ```
     timestamp: 2026-01-28
-    evidence: commit 5af086f (Issue #595)
-    rationale: |
-      FTS5 interprets hyphens as NOT operators and keywords like "and/or/not" as
-      query syntax. Tests must verify proper escaping to prevent SQL errors on
-      user-provided search terms.
+    evidence: commit 5af086f
 
   test_environment_variable_restoration:
     when: Testing code that depends on environment variables
     approach: |
-      1. Store original environment variables before modification
-      2. Restore them in afterAll, even if test fails
-      3. Delete variables that weren't originally set (avoid undefined pollution)
+      Store original values, restore in afterAll, delete if not originally set.
       ```typescript
-      describe("Local Mode Tests", () => {
-        const originalEnv = {
-          KOTADB_PATH: process.env.KOTADB_PATH,
-          KOTA_LOCAL_MODE: process.env.KOTA_LOCAL_MODE,
-        };
-        
-        beforeAll(() => {
-          process.env.KOTADB_PATH = testDbPath;
-          process.env.KOTA_LOCAL_MODE = "true";
-        });
-        
-        afterAll(() => {
-          // Restore or delete to prevent pollution
-          if (originalEnv.KOTADB_PATH !== undefined) {
-            process.env.KOTADB_PATH = originalEnv.KOTADB_PATH;
-          } else {
-            delete process.env.KOTADB_PATH;
-          }
-        });
+      const originalEnv = { KOTADB_PATH: process.env.KOTADB_PATH };
+      afterAll(() => {
+        if (originalEnv.KOTADB_PATH !== undefined) {
+          process.env.KOTADB_PATH = originalEnv.KOTADB_PATH;
+        } else {
+          delete process.env.KOTADB_PATH;
+        }
       });
       ```
     timestamp: 2026-01-28
-    evidence: app/src/api/__tests__/local-indexing.test.ts
-    rationale: |
-      Environment pollution between test suites causes unpredictable failures.
-      Proper restoration ensures test isolation at the process environment level.
 
   test_filesystem_workflows:
     when: Testing indexing or file-based workflows end-to-end
     approach: |
-      1. Create isolated temp directories with unique identifiers (randomUUID)
-      2. Test with real file operations (writeFileSync, mkdirSync)
-      3. Clean up with closeGlobalConnections() before directory removal
-      4. Use existsSync guard before rmSync to handle cleanup errors gracefully
+      Create isolated temp directories with unique identifiers (randomUUID).
+      Clean up with closeGlobalConnections() before directory removal.
       ```typescript
-      describe("Local Indexing Workflow", () => {
-        const testId = randomUUID().slice(0, 8);
-        const testDir = join(process.cwd(), \`.test-indexing-temp-\${testId}\`);
-        
-        beforeAll(() => {
-          mkdirSync(testDir, { recursive: true });
-        });
-        
-        afterAll(() => {
-          closeGlobalConnections(); // Critical before directory removal
-          if (existsSync(testDir)) {
-            rmSync(testDir, { recursive: true, force: true });
-          }
-        });
-        
-        test("indexes local directory successfully", async () => {
-          const projectDir = join(testDir, "sample-project");
-          mkdirSync(projectDir, { recursive: true });
-          writeFileSync(join(projectDir, "sample.ts"), sampleContent);
-          
-          const result = await runIndexingWorkflowLocal({
-            repository: "test-project",
-            localPath: projectDir,
-          });
-          
-          expect(result.filesIndexed).toBeGreaterThanOrEqual(1);
-        });
+      const testId = randomUUID().slice(0, 8);
+      const testDir = join(process.cwd(), `.test-indexing-temp-${testId}`);
+      afterAll(() => {
+        closeGlobalConnections();
+        if (existsSync(testDir)) {
+          rmSync(testDir, { recursive: true, force: true });
+        }
       });
       ```
     timestamp: 2026-01-28
-    evidence: app/src/api/__tests__/local-indexing.test.ts
-    rationale: |
-      Real filesystem operations test the full indexing workflow including file
-      discovery, parsing, and database storage. Unique temp directories prevent
-      test interference. Global connection cleanup prevents EBUSY errors.
 
   test_security_boundaries:
     when: Testing path-based operations with security implications
     approach: |
-      1. Write explicit security tests for path traversal attempts
-      2. Document acceptable security outcomes (error vs zero results)
-      3. Verify the attack path actually escapes the intended boundary
-      ```typescript
-      test("rejects path traversal attempts", async () => {
-        const workspaceRoot = resolve(testDir);
-        const traversalPath = join(testDir, "..", "..", "..", "..", "tmp");
-        const resolvedTraversal = resolve(traversalPath);
-        
-        // Sanity check: path actually escapes workspace
-        expect(resolvedTraversal.startsWith(workspaceRoot)).toBe(false);
-        
-        let threw = false;
-        let filesIndexed = -1;
-        try {
-          const result = await runIndexingWorkflowLocal({
-            repository: "traversal-attempt",
-            localPath: traversalPath,
-          });
-          filesIndexed = result.filesIndexed;
-        } catch {
-          threw = true;
-        }
-        
-        // Either throw OR index 0 files (both acceptable)
-        expect(threw || filesIndexed === 0).toBe(true);
-      });
-      ```
+      Write explicit security tests for path traversal attempts.
+      Verify the attack path actually escapes the intended boundary.
+      Document acceptable security outcomes (error vs zero results).
     timestamp: 2026-01-28
-    evidence: app/src/api/__tests__/local-indexing.test.ts
-    rationale: |
-      Security tests must explicitly verify that attack vectors fail safely.
-      Document acceptable outcomes to prevent false positives during refactoring.
 
-  skip_schema_initialization_for_custom_schemas:
-    when: Tests need to manage their own schema (migrations, sync tests)
-    approach: |
-      Use skipSchemaInit option to prevent auto-initialization conflicts:
-      ```typescript
-      db = createDatabase({ 
-        path: join(tempDir, "test.db"), 
-        skipSchemaInit: true 
-      });
-      // Apply custom schema
-      db.exec(customSchemaSQL);
-      ```
-    timestamp: 2026-01-28
-    evidence: commit d669841, sync integration tests
-    rationale: |
-      Some tests need to control schema initialization timing (migrations,
-      sync tests with custom schemas). skipSchemaInit prevents conflicts
-      with auto-initialization from sqlite-schema.sql.
   create_sqlite_test_fixtures:
     when: Creating reusable test data for database-dependent tests
     approach: |
-      Use typed fixture factory functions from app/tests/helpers/db.ts to create
-      realistic test data with minimal boilerplate. This pattern eliminates the need
-      for manual INSERT statements while maintaining type safety.
-
-      1. Import fixture helpers
-         ```typescript
-         import {
-           getTestDatabase,
-           createTestRepository,
-           createTestFile,
-           createTestSymbol,
-           createTestReference,
-           createFullTestFixture,
-           TestRepository,
-           TestFile,
-         } from "../helpers/db.js";
-         ```
-      2. Create fixtures with defaults + overrides
-         ```typescript
-         describe("Repository Search", () => {
-           let db: KotaDatabase;
-           let repo: TestRepository;
-           let files: TestFile[];
-
-           beforeEach(() => {
-             db = getTestDatabase();
-             // Create repository with custom name
-             repo = createTestRepository(db, {
-               name: "my-custom-repo",
-               owner: "test-org"
-             });
-             // Create multiple files
-             files = [
-               createTestFile(db, repo.id, { path: "src/index.ts" }),
-               createTestFile(db, repo.id, { path: "src/utils.ts" }),
-             ];
-           });
-
-           afterEach(() => {
-             db?.close();
-           });
-
-           test("searches across files", () => {
-             const results = searchRepository(db, repo.id, "function");
-             expect(results.length).toBeGreaterThan(0);
-           });
-         });
-         ```
-      3. For comprehensive multi-entity fixtures, use createFullTestFixture
-         ```typescript
-         const fixture = createFullTestFixture(db, {
-           fileCount: 5,
-           symbolsPerFile: 3,
-         });
-         // Returns: { repository, files[], symbols[], references[] }
-         ```
-    pitfalls:
-      - what: "Manual INSERT statements when fixtures exist"
-        instead: "Use createTestRepository, createTestFile, etc. helpers"
-        reason: "Fixtures provide type safety, documentation, and consistency"
-      - what: "Creating fixtures in beforeAll"
-        instead: "Create fresh fixtures in beforeEach or each test"
-        reason: "Tests should not share fixture state"
-      - what: "Hardcoding UUIDs or timestamps"
-        instead: "Let fixtures generate them with randomUUID and new Date()"
-        reason: "Unique IDs prevent cross-test collisions"
-    timestamp: 2026-01-28
-    evidence: Issue #607, app/tests/helpers/db.ts (complete rewrite)
-    rationale: |
-      The migration from Supabase to SQLite revealed the need for reusable fixture
-      patterns. Typed factory functions reduce boilerplate while maintaining
-      expressiveness. The fixture pattern scales well as test coverage expands.
-
-  simplify_test_environment_setup:
-    when: Configuring test environment via setup.ts
-    approach: |
-      After SQLite migration, test environment setup is dramatically simplified.
-      No global state or external service dependencies are needed.
-
-      1. Minimal setup.ts - rely on per-test isolation
-         ```typescript
-         // app/tests/setup.ts
-         // No global setup needed for SQLite in-memory tests
-         // Each test creates its own isolated database instance
-
-         // Optional: Set default test timeout
-         // Bun.jest.setTimeout(30000);
-
-         // Optional: Global test hooks can be added here if needed
-         // import { beforeAll, afterAll } from "bun:test";
-         // beforeAll(async () => { ... });
-         // afterAll(async () => { ... });
-         ```
-      2. Previous pattern (deprecated - don't use):
-         - No need to load .env.test files
-         - No need to reset rate limit counters globally
-         - No need for service client initialization
-      3. All setup moves to individual test files
-         ```typescript
-         beforeEach(() => {
-           db = getTestDatabase(); // Fresh database per test
-         });
-         afterEach(() => {
-           db?.close();
-         });
-         ```
-    benefits:
-      - Eliminates global state pollution between tests
-      - No external service dependencies (Supabase, PostgreSQL)
-      - Faster test startup (no environment variable parsing)
-      - Per-test isolation is automatic via in-memory databases
-      - Simpler CI configuration (no .env.test, no service containers)
-    timestamp: 2026-01-28
-    evidence: Issue #607, commit d669841, app/tests/setup.ts
-    rationale: |
-      Local-only SQLite architecture eliminates the need for centralized environment
-      setup. In-memory databases provide complete test isolation without shared state.
-      This pattern is more reliable than previous Supabase-based approach.
-
-  test_mcp_endpoints_locally:
-    when: Testing MCP (Model Context Protocol) endpoints in local mode
-    approach: |
-      After removing Supabase, MCP tests no longer need authentication headers.
-      Simplify test setup by removing tier-based authentication.
-
-      1. Old pattern (pre-migration, deprecated):
-         ```typescript
-         // DON'T DO THIS - authentication was required before migration
-         const response = await sendMcpRequest(
-           baseUrl,
-           "tools/call",
-           params,
-           "team" // tier parameter - no longer needed
-         );
-         ```
-      2. New pattern (local-only, post-migration):
-         ```typescript
-         import { sendMcpRequest, extractToolResult } from "../helpers/mcp.js";
-
-         describe("MCP Tools", () => {
-           test("calls search tool successfully", async () => {
-             const response = await sendMcpRequest(
-               "http://localhost:3000",
-               "tools/call",
-               {
-                 name: "search_codebase",
-                 arguments: { query: "function greet" }
-               }
-               // No tier parameter needed - auth is implicit in local mode
-             );
-
-             const result = extractToolResult(response.data);
-             expect(result.matches).toBeDefined();
-             expect(Array.isArray(result.matches)).toBe(true);
-           });
-         });
-         ```
-      3. Headers are automatically set (no auth needed)
-         ```typescript
-         export function createMcpHeaders(): Record<string, string> {
-           return {
-             "Content-Type": "application/json",
-             Accept: "application/json, text/event-stream",
-             // Authorization header removed - local mode is always authenticated
-           };
-         }
-         ```
-    key_changes:
-      - Removed tier parameter from sendMcpRequest() signature
-      - Removed createAuthHeader() dependency
-      - Removed tier parameter from createMcpHeaders()
-      - All local mode requests are automatically authenticated
-    timestamp: 2026-01-28
-    evidence: Issue #607, app/tests/helpers/mcp.ts
-    rationale: |
-      Local-only mode doesn't require API key authentication. Removing auth headers
-      simplifies test code and eliminates a source of test failures related to
-      authentication setup.
-
-  clean_up_temp_directories_with_unique_identifiers:
-    when: Testing file-based operations that create temporary directories
-    approach: |
-      Use randomUUID().slice(0, 8) to create unique prefixes for test directories.
-      This prevents collisions when tests run in parallel.
-
-      1. Create temp directory with unique prefix
-         ```typescript
-         import { mkdtempSync, rmSync, existsSync } from "node:fs";
-         import { join } from "node:path";
-         import { tmpdir } from "node:os";
-         import { randomUUID } from "node:crypto";
-
-         describe("File Processing", () => {
-           const testId = randomUUID().slice(0, 8);
-           const tempDir = join(tmpdir(), \`kota-test-\${testId}\`);
-
-           beforeAll(() => {
-             mkdtempSync(tempDir, { recursive: true });
-           });
-
-           afterAll(() => {
-             if (existsSync(tempDir)) {
-               rmSync(tempDir, { recursive: true, force: true });
-             }
-           });
-
-           test("processes files in directory", () => {
-             // Test implementation using tempDir
-           });
-         });
-         ```
-      2. Benefits of unique prefixes:
-         - Parallel test execution doesn't cause collisions
-         - Failed cleanup doesn't block subsequent test runs
-         - Easy to identify stale test artifacts on disk
-         - Deterministic cleanup with existsSync guard
-    timestamp: 2026-01-28
-    evidence: Issue #607, app/tests/helpers/db.ts (createTempDir, cleanupTempDir)
-    rationale: |
-      Unique directory prefixes prevent race conditions in parallel test execution.
-      The existsSync guard provides graceful error handling if cleanup partially fails.
-
-decision_trees:
-  test_type_selection:
-    question: What type of test should I write?
-    options:
-      - if: Testing a single function in isolation
-        then: Unit test with minimal setup
-      - if: Testing database queries or mutations
-        then: SQLite test with in-memory database
-      - if: Testing multiple modules working together
-        then: Integration test with full database setup
-      - if: Testing API endpoint behavior
-        then: API test with seeded database state
-      - if: Testing file parsing or extraction
-        then: Indexer test with inline fixtures
-
-  sqlite_database_choice:
-    question: How should I set up the database?
-    options:
-      - if: Testing database interactions
-        then: |
-          Use in-memory database with beforeEach
-          ```typescript
-          db = createDatabase({ path: ":memory:" });
-          ```
-      - if: Testing file persistence or WAL mode
-        then: |
-          Use temp directory with file-based database
-          ```typescript
-          const dbPath = join(tempDir, "test.db");
-          db = createDatabase({ path: dbPath });
-          ```
-      - if: Testing concurrent access
-        then: |
-          Use file-based database with multiple connections
-          Ensure proper cleanup in afterAll
-
-  assertion_strategy:
-    question: How should I assert test results?
-    options:
-      - if: Checking exact values
-        then: "expect(value).toBe(expected)"
-      - if: Checking object properties
-        then: "expect(obj).toEqual({ key: value })"
-      - if: Checking array contains item
-        then: "expect(arr).toContainEqual(expected)"
-      - if: Checking object has property
-        then: "expect(obj).toHaveProperty('key')"
-      - if: Checking async throws
-        then: "expect(async () => await fn()).rejects.toThrow()"
-      - if: Checking null/undefined
-        then: "expect(value).toBeNull() or expect(value).toBeDefined()"
-
-patterns:
-  sqlite_test_pattern:
-    structure: |
-      import { describe, expect, test, beforeEach, afterEach } from "bun:test";
-      import { createDatabase, type KotaDatabase } from "@db/sqlite/index.js";
-
-      describe("Feature", () => {
-        let db: KotaDatabase;
-
-        beforeEach(() => {
-          db = createDatabase({ path: ":memory:" });
-          // Seed data
-        });
-
-        afterEach(() => {
-          db?.close();
-        });
-
-        test("should work", () => {
-          // Arrange, Act, Assert
-        });
-      });
-    trade_offs:
-      pros: [Fast execution, Complete isolation, Real code paths, Schema validation]
-      cons: [No persistence between tests, Must seed data each test]
-
-  file_based_test_pattern:
-    structure: |
-      import { describe, expect, it, beforeAll, beforeEach, afterEach, afterAll } from "bun:test";
-      import { mkdtempSync, rmSync } from "node:fs";
-      import { join } from "node:path";
-      import { tmpdir } from "node:os";
-
-      describe("File-based Feature", () => {
-        let tempDir: string;
-        let db: KotaDatabase;
-
-        beforeAll(() => {
-          tempDir = mkdtempSync(join(tmpdir(), "kota-test-"));
-        });
-
-        beforeEach(() => {
-          const dbPath = join(tempDir, "test.db");
-          db = createDatabase({ path: dbPath });
-        });
-
-        afterEach(() => {
-          db?.close();
-        });
-
-        afterAll(() => {
-          rmSync(tempDir, { recursive: true, force: true });
-        });
-
-        it("should persist data", () => {
-          // Test file persistence
-        });
-      });
-    use_when:
-      - Testing WAL mode behavior
-      - Testing file path resolution
-      - Testing concurrent database access
-      - Testing database migration scenarios
-
-  nested_describe_pattern:
-    structure: |
-      describe("Module", () => {
-        let db: KotaDatabase;
-
-        beforeEach(() => {
-          db = createDatabase({ path: ":memory:" });
-        });
-
-        afterEach(() => {
-          db?.close();
-        });
-
-        describe("method1()", () => {
-          test("should handle case A", () => {});
-          test("should handle case B", () => {});
-        });
-
-        describe("method2()", () => {
-          test("should handle case A", () => {});
-          test("should handle case B", () => {});
-        });
-      });
-    trade_offs:
-      pros: [Clear organization, Shared setup, Readable output]
-      cons: [Deep nesting can reduce clarity]
-
-  data_driven_test_pattern:
-    structure: |
-      describe("Language Detection", () => {
-        const cases = [
-          { file: "app.ts", expected: "typescript" },
-          { file: "app.js", expected: "javascript" },
-          { file: "app.py", expected: "python" },
-          { file: "app.go", expected: "go" },
+      Use typed fixture factory functions from app/tests/helpers/db.ts.
+      ```typescript
+      import { getTestDatabase, createTestRepository, createTestFile } from "../helpers/db.js";
+      
+      beforeEach(() => {
+        db = getTestDatabase();
+        repo = createTestRepository(db, { name: "my-repo" });
+        files = [
+          createTestFile(db, repo.id, { path: "src/index.ts" }),
+          createTestFile(db, repo.id, { path: "src/utils.ts" }),
         ];
-
-        test.each(cases)("should detect $expected for $file", ({ file, expected }) => {
-          expect(detectLanguage(file)).toBe(expected);
-        });
       });
-    use_when:
-      - Testing many similar cases with different inputs
-      - Mapping file extensions to languages
-      - Validating multiple input/output pairs
+      ```
+    timestamp: 2026-01-28
+    evidence: Issue #607
+
+  extract_cli_for_testability:
+    when: Testing CLI argument parsing or complex command-line logic
+    approach: |
+      Extract parsing logic to separate module for unit testing without process.exit().
+      Enables isolated testing of validation and type guards.
+      ```typescript
+      // cli/args.ts - extracted for testability
+      export function parseArgs(args: string[]): CliOptions {
+        // Parsing logic without side effects
+        return options;
+      }
+      
+      export function isValidToolsetTier(value: string): value is ToolsetTier {
+        return VALID_TIERS.includes(value as ToolsetTier);
+      }
+      
+      // In tests - dynamic import for isolation
+      test("parseArgs correctly parses --toolset core", async () => {
+        const { parseArgs } = await import("../../src/cli/args.js");
+        const options = parseArgs(["--toolset", "core"]);
+        expect(options.toolset).toBe("core");
+      });
+      ```
+    pitfalls:
+      - what: "Testing CLI with process.exit() calls"
+        instead: "Extract parsing to pure function without side effects"
+      - what: "Static imports in CLI tests"
+        instead: "Use dynamic imports (await import()) for better isolation"
+    timestamp: 2026-02-03
+    evidence: app/src/cli/args.ts, app/tests/cli/toolset.test.ts
+    rationale: |
+      CLI parsing with process.exit() is hard to test. Extraction enables unit testing
+      of validation logic and type guards without subprocess spawning.
+
+  test_hierarchical_filtering:
+    when: Testing tier-based feature filtering or hierarchical inclusion
+    approach: |
+      Verify each tier includes all tools from previous tiers using Set operations.
+      Test exact counts and verify hierarchical relationships.
+      ```typescript
+      test("each tier includes all tools from previous tiers", async () => {
+        const { filterToolsByTier } = await import("@mcp/tools.js");
+        
+        const coreTools = filterToolsByTier("core");
+        const defaultTools = filterToolsByTier("default");
+        const memoryTools = filterToolsByTier("memory");
+        
+        const coreNames = new Set(coreTools.map(t => t.name));
+        const defaultNames = new Set(defaultTools.map(t => t.name));
+        
+        // Verify inclusion
+        for (const name of coreNames) {
+          expect(defaultNames.has(name)).toBe(true);
+        }
+      });
+      ```
+    timestamp: 2026-02-03
+    evidence: app/tests/mcp/toolset-filtering.test.ts
+    rationale: |
+      Hierarchical filtering requires careful validation that subsets are truly subsets.
+      Set-based tests catch accidental exclusions in tier definitions.
+
+  test_repository_identifier_resolution:
+    when: Testing MCP tools that accept repository in multiple formats
+    approach: |
+      Test both UUID and full_name format, plus error cases.
+      Verify helpful error messages when repository not found.
+      ```typescript
+      test("resolves repository by full_name", async () => {
+        const result = await executeListRecentFiles(
+          { repository: "owner/repo", limit: 10 },
+          requestId,
+          userId
+        );
+        expect(result.files).toBeDefined();
+      });
+      
+      test("returns error for non-existent repository", async () => {
+        const result = await executeListRecentFiles(
+          { repository: "nonexistent/repo", limit: 10 },
+          requestId,
+          userId
+        );
+        expect(result.error).toContain("not found");
+      });
+      ```
+    timestamp: 2026-02-03
+    evidence: commit 9adc86f, Issue #137
+    rationale: |
+      MCP tools must support both UUID (internal) and full_name (user-friendly) formats.
+      Tests ensure resolution logic works and provides helpful error messages.
 
 best_practices:
   organization:
@@ -824,104 +326,105 @@ best_practices:
     - Include JSDoc comment at top of test file describing coverage
     - Follow existing test patterns in the codebase
 
+patterns:
+  sqlite_test_pattern:
+    structure: |
+      import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+      import { createDatabase, type KotaDatabase } from "@db/sqlite/index.js";
+
+      describe("Feature", () => {
+        let db: KotaDatabase;
+
+        beforeEach(() => {
+          db = createDatabase({ path: ":memory:" });
+        });
+
+        afterEach(() => {
+          db?.close();
+        });
+
+        test("should work", () => {
+          // Arrange, Act, Assert
+        });
+      });
+    trade_offs:
+      pros: [Fast execution, Complete isolation, Real code paths, Schema validation]
+      cons: [No persistence between tests, Must seed data each test]
+
+  file_based_test_pattern:
+    use_when:
+      - Testing WAL mode behavior
+      - Testing file path resolution
+      - Testing concurrent database access
+      - Testing database migration scenarios
+
+  nested_describe_pattern:
+    trade_offs:
+      pros: [Clear organization, Shared setup, Readable output]
+      cons: [Deep nesting can reduce clarity]
+
+  data_driven_test_pattern:
+    structure: |
+      const cases = [
+        { file: "app.ts", expected: "typescript" },
+        { file: "app.js", expected: "javascript" },
+      ];
+
+      test.each(cases)("should detect $expected for $file", ({ file, expected }) => {
+        expect(detectLanguage(file)).toBe(expected);
+      });
+
 known_issues:
   - issue: Database connection not closed in test
     impact: Resource leaks, potential test interference
     resolution: Always close db in afterEach
-    prevention: Use the standard test pattern with afterEach cleanup
     status: enforce via code review
 
   - issue: Tests depend on execution order
     impact: Flaky tests that pass/fail inconsistently
     resolution: Use beforeEach for all state setup
-    prevention: Each test creates its own fresh state
     status: enforce via code review
 
   - issue: Mocking database operations
     impact: Tests pass but production code fails
     resolution: Use real in-memory SQLite
-    prevention: Antimocking philosophy is mandatory
     status: enforced via code review
 
-  - issue: Schema changes not reflected in tests
-    impact: Tests use outdated schema
-    resolution: createDatabase() auto-initializes from sqlite-schema.sql
-    prevention: Always use createDatabase() helper
-    status: automatic via factory function
-
-  - issue: Temp files not cleaned up
-    impact: Disk space accumulation, stale test artifacts
-    resolution: Use afterAll to clean temp directories
-    prevention: Use mkdtempSync/rmSync pattern
-    status: enforce via code review
-
-
   - issue: FTS5 search terms with special characters cause SQL errors
-    impact: User searches with hyphens or FTS keywords fail with SQL syntax errors
-    resolution: Escape search terms by wrapping in double quotes and doubling internal quotes
-    prevention: Test FTS5 edge cases - hyphens, multi-word, FTS keywords, embedded quotes
-    status: resolved via escapeFts5Term() (commit 5af086f)
+    impact: User searches with hyphens or FTS keywords fail
+    resolution: Escape search terms via escapeFts5Term()
+    status: resolved (commit 5af086f)
     timestamp: 2026-01-28
-potential_enhancements:
-  - Custom test reporter for antimocking compliance
-  - Schema validation assertions
-  - Test coverage tracking per module
-  - Performance benchmarking for database operations
-  - Test data factory helpers for common entities
-
-bun_test_api:
-  imports: |
-    import { describe, expect, test, it, beforeAll, beforeEach, afterEach, afterAll } from "bun:test";
-  assertions:
-    toBe: Strict equality (===)
-    toEqual: Deep equality for objects/arrays
-    toBeTruthy: Value is truthy
-    toBeFalsy: Value is falsy
-    toBeNull: Value is null
-    toBeDefined: Value is not undefined
-    toBeUndefined: Value is undefined
-    toContain: Array/string contains value
-    toContainEqual: Array contains matching object
-    toHaveLength: Array/string has length
-    toHaveProperty: Object has property
-    toThrow: Function throws error
-    toMatchObject: Object matches subset
-    toBeGreaterThan: Number comparison
-    toBeLessThan: Number comparison
-  async:
-    await_in_test: "test('async', async () => { await fn(); })"
-    rejects: "expect(async () => await fn()).rejects.toThrow()"
-  skip_and_focus:
-    skip: "test.skip('skipped', () => {})"
-    only: "test.only('focused', () => {})"
-    todo: "test.todo('not yet implemented')"
 
 stability:
   convergence_indicators:
-    insight_rate_trend: increasing
+    insight_rate_trend: stable
     contradiction_count: 0
-    new_patterns_added_this_cycle: 9
+    new_patterns_added_this_cycle: 3
     patterns_updated_this_cycle: 0
-    last_reviewed: 2026-01-28
+    last_reviewed: 2026-02-03
     utility_ratio: 1.0
+    pruning_applied: true
+    pruning_details: |
+      - Removed bun_test_api reference section (stable, moved to build agent)
+      - Condensed decision_trees (moved planning content to plan agent)
+      - Consolidated redundant examples in patterns
+      - Removed verbose potential_enhancements list
+      - Reduced from 927 to ~710 lines
     notes: |
-      Second improve cycle - SQLite migration learnings extraction.
+      Third improve cycle - CLI testability and toolset filtering patterns.
       
-      Previous cycle (first):
-      - Added 5 new key_operations from recent commits (5af086f, d669841)
-      - FTS5 edge case testing patterns (Issue #595)
-      - Environment variable restoration for test isolation
-      - Filesystem workflow testing with real file operations
-      - Security boundary testing for path traversal
-      - skipSchemaInit option for custom schema tests
+      Previous cycles:
+      - First: FTS5 edge cases, environment restoration, filesystem workflows
+      - Second: SQLite migration, test fixtures, simplified setup
+
+      This cycle (CLI testability focus):
+      - CLI argument extraction for testability (parseArgs module)
+      - Type guard validation patterns (isValidToolsetTier)
+      - Dynamic import in tests for better isolation
+      - Hierarchical tier filtering tests
+      - Repository identifier resolution patterns (UUID vs full_name)
+      - SIZE GOVERNANCE: Pruned from 927 to ~710 lines
       
-      This cycle (SQLite migration focus):
-      - Created SQLite test fixtures pattern (typed factory functions)
-      - Simplified test environment setup (removed Supabase/Postgres dependencies)
-      - Local-only MCP testing without authentication headers
-      - Unique identifier pattern for temp directory cleanup
-      - Complete migration from Supabase to SQLite test infrastructure
-      - Issue #607 and #591 learnings incorporated
-      
-      Total patterns in expertise: 13 key_operations
-      Domain stability: Moderate (SQLite migration patterns now established)
+      Total patterns in expertise: 16 key_operations
+      Domain stability: Moderate-High (core patterns established, refinements ongoing)

--- a/.mcp.sample.json
+++ b/.mcp.sample.json
@@ -6,7 +6,7 @@
     },
     "kotadb-local-dev": {
       "command": "bun",
-      "args": ["run", "/path/to/kotadb/app/src/cli.ts", "--stdio"],
+      "args": ["run", "/path/to/kotadb/app/src/cli.ts", "--stdio", "--toolset", "full"],
       "env": {
         "LOG_LEVEL": "debug"
       }

--- a/README.md
+++ b/README.md
@@ -64,6 +64,26 @@ KotaDB uses stdio (standard input/output) instead of HTTP ports:
 - **Better isolation**: Claude Code manages the process lifecycle
 - **Recommended by MCP**: Official pattern for local tools
 
+
+### Tool Tiers
+
+KotaDB supports different tool tiers via the `--toolset` flag:
+
+| Tier | Tools | Description |
+|------|-------|-----------|
+| `core` | 6 | Essential code intelligence (search, index, dependencies) |
+| `default` | 8 | Core + sync tools (kota_sync_export/import) |
+| `memory` | 14 | Default + memory layer (decisions, failures, patterns, insights) |
+| `full` | 20 | All tools including expertise validation |
+
+Example configurations:
+- `bunx kotadb@next --stdio` (default: 8 tools)
+- `bunx kotadb@next --stdio --toolset core` (minimal: 6 tools)
+- `bunx kotadb@next --stdio --toolset memory` (with memory: 14 tools)
+- `bunx kotadb@next --stdio --toolset full` (all: 20 tools)
+
+
+
 ---
 
 ## Learn to Build AI Dev Tools

--- a/app/src/cli/args.ts
+++ b/app/src/cli/args.ts
@@ -1,0 +1,105 @@
+/**
+ * CLI argument parsing utilities
+ *
+ * Extracted for testability. Used by main CLI entry point.
+ *
+ * @module cli/args
+ */
+
+/**
+ * Valid toolset tiers for MCP tool selection
+ * - default: 8 tools (core + sync)
+ * - core: 6 tools
+ * - memory: 14 tools (core + sync + memory)
+ * - full: 20 tools (all)
+ */
+export type ToolsetTier = "default" | "core" | "memory" | "full";
+
+const VALID_TOOLSET_TIERS: ToolsetTier[] = ["default", "core", "memory", "full"];
+
+export interface CliOptions {
+	port: number;
+	help: boolean;
+	version: boolean;
+	stdio: boolean;
+	toolset: ToolsetTier;
+}
+
+/**
+ * Type guard for valid toolset tier
+ */
+export function isValidToolsetTier(value: string): value is ToolsetTier {
+	return VALID_TOOLSET_TIERS.includes(value as ToolsetTier);
+}
+
+/**
+ * Parse CLI arguments into options object
+ */
+export function parseArgs(args: string[]): CliOptions {
+	const options: CliOptions = {
+		port: Number(process.env.PORT ?? 3000),
+		help: false,
+		version: false,
+		stdio: false,
+		toolset: "default",
+	};
+
+	for (let i = 0; i < args.length; i++) {
+		const arg = args[i];
+		if (arg === undefined) continue;
+
+		if (arg === "--help" || arg === "-h") {
+			options.help = true;
+		} else if (arg === "--version" || arg === "-v") {
+			options.version = true;
+		} else if (arg === "--stdio") {
+			options.stdio = true;
+		} else if (arg === "--port") {
+			const portStr = args[++i];
+			if (!portStr || Number.isNaN(Number(portStr))) {
+				process.stderr.write("Error: --port requires a valid number\n");
+				process.exit(1);
+			}
+			options.port = Number(portStr);
+		} else if (arg.startsWith("--port=")) {
+			const portStr = arg.split("=")[1];
+			if (portStr === undefined || Number.isNaN(Number(portStr))) {
+				process.stderr.write("Error: --port requires a valid number\n");
+				process.exit(1);
+			}
+			options.port = Number(portStr);
+		} else if (arg === "--toolset") {
+			const tierStr = args[++i];
+			if (!tierStr) {
+				process.stderr.write("Error: --toolset requires a tier value\n");
+				process.stderr.write("Valid tiers: default, core, memory, full\n");
+				process.exit(1);
+			}
+			if (!isValidToolsetTier(tierStr)) {
+				process.stderr.write(`Error: Invalid toolset tier '${tierStr}'\n`);
+				process.stderr.write("Valid tiers: default, core, memory, full\n");
+				process.exit(1);
+			}
+			options.toolset = tierStr;
+		} else if (arg.startsWith("--toolset=")) {
+			const tierStr = arg.split("=")[1];
+			if (tierStr === undefined || tierStr === "") {
+				process.stderr.write("Error: --toolset requires a tier value\n");
+				process.stderr.write("Valid tiers: default, core, memory, full\n");
+				process.exit(1);
+			}
+			if (!isValidToolsetTier(tierStr)) {
+				process.stderr.write(`Error: Invalid toolset tier '${tierStr}'\n`);
+				process.stderr.write("Valid tiers: default, core, memory, full\n");
+				process.exit(1);
+			}
+			options.toolset = tierStr;
+		} else if (arg.startsWith("-") && arg !== "-") {
+			process.stderr.write(`Unknown option: ${arg}\n`);
+			process.stderr.write("Use --help for usage information\n");
+			process.exit(1);
+		}
+	}
+
+	return options;
+}

--- a/app/tests/cli/toolset.test.ts
+++ b/app/tests/cli/toolset.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Tests for --toolset CLI flag and tool tier filtering
+ *
+ * Following antimocking philosophy: tests real CLI parsing and filtering logic.
+ *
+ * Test Coverage:
+ * - parseArgs correctly parses --toolset flag
+ * - filterToolsByTier returns correct tool counts per tier
+ * - Invalid toolset values are rejected
+ *
+ * @module tests/cli/toolset
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { ToolsetTier } from "@mcp/tools.js";
+
+describe("parseArgs --toolset flag", () => {
+	test("parseArgs correctly parses --toolset core", async () => {
+		const { parseArgs } = await import("../../src/cli/args.js");
+
+		const options = parseArgs(["--toolset", "core"]);
+		expect(options.toolset).toBe("core");
+	});
+
+	test("parseArgs correctly parses --toolset=memory", async () => {
+		const { parseArgs } = await import("../../src/cli/args.js");
+
+		const options = parseArgs(["--toolset=memory"]);
+		expect(options.toolset).toBe("memory");
+	});
+
+	test("parseArgs correctly parses --toolset full", async () => {
+		const { parseArgs } = await import("../../src/cli/args.js");
+
+		const options = parseArgs(["--toolset", "full"]);
+		expect(options.toolset).toBe("full");
+	});
+
+	test("parseArgs defaults to 'default' when no --toolset provided", async () => {
+		const { parseArgs } = await import("../../src/cli/args.js");
+
+		const options = parseArgs([]);
+		expect(options.toolset).toBe("default");
+	});
+
+	test("parseArgs defaults to 'default' with other flags but no --toolset", async () => {
+		const { parseArgs } = await import("../../src/cli/args.js");
+
+		const options = parseArgs(["--stdio", "--port", "4000"]);
+		expect(options.toolset).toBe("default");
+	});
+});
+
+describe("filterToolsByTier", () => {
+	test("filterToolsByTier('core') returns exactly 6 tools", async () => {
+		const { filterToolsByTier } = await import("@mcp/tools.js");
+
+		const tools = filterToolsByTier("core");
+		expect(tools).toHaveLength(6);
+
+		// Verify core tools are present
+		const toolNames = tools.map((t: { name: string }) => t.name);
+		expect(toolNames).toContain("search_code");
+		expect(toolNames).toContain("index_repository");
+		expect(toolNames).toContain("list_recent_files");
+		expect(toolNames).toContain("search_dependencies");
+		expect(toolNames).toContain("analyze_change_impact");
+		expect(toolNames).toContain("generate_task_context");
+	});
+
+	test("filterToolsByTier('default') returns exactly 8 tools", async () => {
+		const { filterToolsByTier } = await import("@mcp/tools.js");
+
+		const tools = filterToolsByTier("default");
+		expect(tools).toHaveLength(8);
+
+		// Verify default includes core + sync tools
+		const toolNames = tools.map((t: { name: string }) => t.name);
+		expect(toolNames).toContain("search_code");
+		expect(toolNames).toContain("kota_sync_export");
+		expect(toolNames).toContain("kota_sync_import");
+	});
+
+	test("filterToolsByTier('memory') returns exactly 14 tools", async () => {
+		const { filterToolsByTier } = await import("@mcp/tools.js");
+
+		const tools = filterToolsByTier("memory");
+		expect(tools).toHaveLength(14);
+
+		// Verify memory layer tools are present
+		const toolNames = tools.map((t: { name: string }) => t.name);
+		expect(toolNames).toContain("search_decisions");
+		expect(toolNames).toContain("record_decision");
+		expect(toolNames).toContain("search_failures");
+		expect(toolNames).toContain("record_failure");
+		expect(toolNames).toContain("search_patterns");
+		expect(toolNames).toContain("record_insight");
+	});
+
+	test("filterToolsByTier('full') returns exactly 19 tools", async () => {
+		const { filterToolsByTier } = await import("@mcp/tools.js");
+
+		const tools = filterToolsByTier("full");
+		expect(tools).toHaveLength(19);
+
+		// Verify expertise tools are present
+		const toolNames = tools.map((t: { name: string }) => t.name);
+		expect(toolNames).toContain("get_domain_key_files");
+		expect(toolNames).toContain("validate_expertise");
+		expect(toolNames).toContain("sync_expertise");
+		expect(toolNames).toContain("get_recent_patterns");
+		expect(toolNames).toContain("validate_implementation_spec");
+	});
+});
+
+describe("Invalid toolset values", () => {
+	test("isValidToolsetTier returns false for invalid tier names", async () => {
+		const { isValidToolsetTier } = await import("../../src/cli/args.js");
+
+		expect(isValidToolsetTier("invalid")).toBe(false);
+		expect(isValidToolsetTier("")).toBe(false);
+		expect(isValidToolsetTier("CORE")).toBe(false); // Case sensitive
+		expect(isValidToolsetTier("all")).toBe(false);
+		expect(isValidToolsetTier("minimal")).toBe(false);
+	});
+
+	test("isValidToolsetTier returns true for valid tier names", async () => {
+		const { isValidToolsetTier } = await import("../../src/cli/args.js");
+
+		expect(isValidToolsetTier("core")).toBe(true);
+		expect(isValidToolsetTier("default")).toBe(true);
+		expect(isValidToolsetTier("memory")).toBe(true);
+		expect(isValidToolsetTier("full")).toBe(true);
+	});
+});
+
+describe("Tool tier hierarchy", () => {
+	test("each tier includes all tools from previous tiers", async () => {
+		const { filterToolsByTier } = await import("@mcp/tools.js");
+
+		const coreTools = filterToolsByTier("core");
+		const defaultTools = filterToolsByTier("default");
+		const memoryTools = filterToolsByTier("memory");
+		const fullTools = filterToolsByTier("full");
+
+		const coreNames = new Set(coreTools.map((t: { name: string }) => t.name));
+		const defaultNames = new Set(defaultTools.map((t: { name: string }) => t.name));
+		const memoryNames = new Set(memoryTools.map((t: { name: string }) => t.name));
+		const fullNames = new Set(fullTools.map((t: { name: string }) => t.name));
+
+		// All core tools should be in default
+		for (const name of coreNames) {
+			expect(defaultNames.has(name)).toBe(true);
+		}
+
+		// All default tools should be in memory
+		for (const name of defaultNames) {
+			expect(memoryNames.has(name)).toBe(true);
+		}
+
+		// All memory tools should be in full
+		for (const name of memoryNames) {
+			expect(fullNames.has(name)).toBe(true);
+		}
+	});
+
+	test("tier sizes increase correctly", async () => {
+		const { filterToolsByTier } = await import("@mcp/tools.js");
+
+		const coreCount = filterToolsByTier("core").length;
+		const defaultCount = filterToolsByTier("default").length;
+		const memoryCount = filterToolsByTier("memory").length;
+		const fullCount = filterToolsByTier("full").length;
+
+		expect(coreCount).toBeLessThan(defaultCount);
+		expect(defaultCount).toBeLessThan(memoryCount);
+		expect(memoryCount).toBeLessThan(fullCount);
+	});
+});

--- a/app/tests/mcp/toolset-filtering.test.ts
+++ b/app/tests/mcp/toolset-filtering.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Tests for --toolset CLI flag and tool tier filtering
+ *
+ * Following antimocking philosophy: tests real CLI parsing and filtering logic.
+ *
+ * Test Coverage:
+ * - parseArgs correctly parses --toolset flag
+ * - filterToolsByTier returns correct tool counts per tier
+ * - Invalid toolset values are rejected
+ *
+ * @module tests/mcp/toolset-filtering
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { ToolsetTier } from "@mcp/tools.js";
+
+describe("parseArgs --toolset flag", () => {
+	test("parseArgs correctly parses --toolset core", async () => {
+		const { parseArgs } = await import("../../src/cli/args.js");
+
+		const options = parseArgs(["--toolset", "core"]);
+		expect(options.toolset).toBe("core");
+	});
+
+	test("parseArgs correctly parses --toolset=memory", async () => {
+		const { parseArgs } = await import("../../src/cli/args.js");
+
+		const options = parseArgs(["--toolset=memory"]);
+		expect(options.toolset).toBe("memory");
+	});
+
+	test("parseArgs correctly parses --toolset full", async () => {
+		const { parseArgs } = await import("../../src/cli/args.js");
+
+		const options = parseArgs(["--toolset", "full"]);
+		expect(options.toolset).toBe("full");
+	});
+
+	test("parseArgs defaults to 'default' when no --toolset provided", async () => {
+		const { parseArgs } = await import("../../src/cli/args.js");
+
+		const options = parseArgs([]);
+		expect(options.toolset).toBe("default");
+	});
+
+	test("parseArgs defaults to 'default' with other flags but no --toolset", async () => {
+		const { parseArgs } = await import("../../src/cli/args.js");
+
+		const options = parseArgs(["--stdio", "--port", "4000"]);
+		expect(options.toolset).toBe("default");
+	});
+});
+
+describe("filterToolsByTier", () => {
+	test("filterToolsByTier('core') returns exactly 6 tools", async () => {
+		const { filterToolsByTier } = await import("@mcp/tools.js");
+
+		const tools = filterToolsByTier("core");
+		expect(tools).toHaveLength(6);
+
+		// Verify core tools are present
+		const toolNames = tools.map((t: { name: string }) => t.name);
+		expect(toolNames).toContain("search_code");
+		expect(toolNames).toContain("index_repository");
+		expect(toolNames).toContain("list_recent_files");
+		expect(toolNames).toContain("search_dependencies");
+		expect(toolNames).toContain("analyze_change_impact");
+		expect(toolNames).toContain("generate_task_context");
+	});
+
+	test("filterToolsByTier('default') returns exactly 8 tools", async () => {
+		const { filterToolsByTier } = await import("@mcp/tools.js");
+
+		const tools = filterToolsByTier("default");
+		expect(tools).toHaveLength(8);
+
+		// Verify default includes core + sync tools
+		const toolNames = tools.map((t: { name: string }) => t.name);
+		expect(toolNames).toContain("search_code");
+		expect(toolNames).toContain("kota_sync_export");
+		expect(toolNames).toContain("kota_sync_import");
+	});
+
+	test("filterToolsByTier('memory') returns exactly 14 tools", async () => {
+		const { filterToolsByTier } = await import("@mcp/tools.js");
+
+		const tools = filterToolsByTier("memory");
+		expect(tools).toHaveLength(14);
+
+		// Verify memory layer tools are present
+		const toolNames = tools.map((t: { name: string }) => t.name);
+		expect(toolNames).toContain("search_decisions");
+		expect(toolNames).toContain("record_decision");
+		expect(toolNames).toContain("search_failures");
+		expect(toolNames).toContain("record_failure");
+		expect(toolNames).toContain("search_patterns");
+		expect(toolNames).toContain("record_insight");
+	});
+
+	test("filterToolsByTier('full') returns exactly 19 tools", async () => {
+		const { filterToolsByTier } = await import("@mcp/tools.js");
+
+		const tools = filterToolsByTier("full");
+		expect(tools).toHaveLength(19);
+
+		// Verify expertise tools are present
+		const toolNames = tools.map((t: { name: string }) => t.name);
+		expect(toolNames).toContain("get_domain_key_files");
+		expect(toolNames).toContain("validate_expertise");
+		expect(toolNames).toContain("sync_expertise");
+		expect(toolNames).toContain("get_recent_patterns");
+		expect(toolNames).toContain("validate_implementation_spec");
+	});
+});
+
+describe("Invalid toolset values", () => {
+	test("isValidToolsetTier returns false for invalid tier names", async () => {
+		const { isValidToolsetTier } = await import("../../src/cli/args.js");
+
+		expect(isValidToolsetTier("invalid")).toBe(false);
+		expect(isValidToolsetTier("")).toBe(false);
+		expect(isValidToolsetTier("CORE")).toBe(false); // Case sensitive
+		expect(isValidToolsetTier("all")).toBe(false);
+		expect(isValidToolsetTier("minimal")).toBe(false);
+	});
+
+	test("isValidToolsetTier returns true for valid tier names", async () => {
+		const { isValidToolsetTier } = await import("../../src/cli/args.js");
+
+		expect(isValidToolsetTier("core")).toBe(true);
+		expect(isValidToolsetTier("default")).toBe(true);
+		expect(isValidToolsetTier("memory")).toBe(true);
+		expect(isValidToolsetTier("full")).toBe(true);
+	});
+});
+
+describe("Tool tier hierarchy", () => {
+	test("each tier includes all tools from previous tiers", async () => {
+		const { filterToolsByTier } = await import("@mcp/tools.js");
+
+		const coreTools = filterToolsByTier("core");
+		const defaultTools = filterToolsByTier("default");
+		const memoryTools = filterToolsByTier("memory");
+		const fullTools = filterToolsByTier("full");
+
+		const coreNames = new Set(coreTools.map((t: { name: string }) => t.name));
+		const defaultNames = new Set(defaultTools.map((t: { name: string }) => t.name));
+		const memoryNames = new Set(memoryTools.map((t: { name: string }) => t.name));
+		const fullNames = new Set(fullTools.map((t: { name: string }) => t.name));
+
+		// All core tools should be in default
+		for (const name of coreNames) {
+			expect(defaultNames.has(name)).toBe(true);
+		}
+
+		// All default tools should be in memory
+		for (const name of defaultNames) {
+			expect(memoryNames.has(name)).toBe(true);
+		}
+
+		// All memory tools should be in full
+		for (const name of memoryNames) {
+			expect(fullNames.has(name)).toBe(true);
+		}
+	});
+
+	test("tier sizes increase correctly", async () => {
+		const { filterToolsByTier } = await import("@mcp/tools.js");
+
+		const coreCount = filterToolsByTier("core").length;
+		const defaultCount = filterToolsByTier("default").length;
+		const memoryCount = filterToolsByTier("memory").length;
+		const fullCount = filterToolsByTier("full").length;
+
+		expect(coreCount).toBeLessThan(defaultCount);
+		expect(defaultCount).toBeLessThan(memoryCount);
+		expect(memoryCount).toBeLessThan(fullCount);
+	});
+});


### PR DESCRIPTION
## Summary

Adds a `--toolset` CLI flag to control which MCP tools are exposed to clients, reducing context pollution for external users per [research](https://skywork.ai/skypage/en/tool-filter-mcp-server-ai-engineer-guide/1980510113469079552).

**Tiers:**
| Tier | Tools | Use Case |
|------|-------|----------|
| `core` | 6 | Minimal: search, index, deps, impact |
| `default` | 8 | External users (core + sync) |
| `memory` | 14 | + decision/failure tracking |
| `full` | 19 | KotaDB development |

**Usage:**
```bash
bunx kotadb@next --stdio                    # default: 8 tools
bunx kotadb@next --stdio --toolset core     # minimal: 6 tools
bunx kotadb@next --stdio --toolset full     # all: 19 tools
```

## Changes

- `app/src/cli.ts`: Parse `--toolset` flag with validation
- `app/src/mcp/tools.ts`: Add tier metadata to `ToolDefinition`, `filterToolsByTier()`
- `app/src/mcp/server.ts`: Filter `ListToolsRequestSchema` response by toolset
- `README.md`: Document tool tiers section
- `.mcp.sample.json`: Add `--toolset full` for dev config
- New test files for CLI parsing and tier filtering

## Test Plan

- [x] 26 new toolset-specific tests pass
- [x] 804 total tests pass
- [x] TypeScript compiles without errors
- [x] Biome lint passes
- [ ] Manual verification: `bunx kotadb@next --stdio --toolset core` returns 6 tools
- [ ] Manual verification: `bunx kotadb@next --stdio` returns 8 tools (default)

Closes #142