### PR TITLE
feat(mcp): add snippet output mode to unified search tool (#152)

### DIFF
--- a/.claude/agents/experts/api/expertise.yaml
+++ b/.claude/agents/experts/api/expertise.yaml
@@ -116,13 +116,44 @@ key_operations:
       - Context combination pattern
       - Always provide capability context (not file-dependent)
 
+  implement_snippet_output_mode:
+    when: Adding snippet output mode for code search (line-based match extraction with context)
+    approach: |
+      1. Create extractLineSnippets(content, query, contextLines) in queries.ts
+      2. Case-insensitive line matching, collect line number + content + context arrays
+      3. Add 'snippet' to output enum, add context_lines parameter (0-10 range validation)
+      4. Update formatSearchResults() to handle snippet mode for code scope
+      5. Fall back to compact format for non-code scopes (snippets only meaningful for files)
+      6. Update tool description with output mode hierarchy and size warnings
+    timestamp: 2026-02-04
+    evidence: app/src/api/queries.ts extractLineSnippets, app/src/mcp/tools.ts SEARCH_TOOL
+    key_patterns:
+      - Output hierarchy: paths (100B) < compact (200B) < snippet (2KB) < full (100KB)
+      - Scope-specific defaults: code='compact', others='full'
+      - Graceful degradation: non-code scopes use compact in snippet mode
+      - Parameter validation: 0-10 range for context_lines with clear error messages
+
+  scope_specific_output_defaults:
+    when: Choosing default output modes based on search scope characteristics
+    approach: |
+      1. Analyze typical result sizes per scope (code=large, symbols=small)
+      2. Default code scope to 'compact' (prevents large responses)
+      3. Default other scopes to 'full' (small payloads, rich detail useful)
+      4. Document rationale in tool description with size warnings
+    timestamp: 2026-02-04
+    evidence: app/src/mcp/tools.ts executeSearch default output selection
+    key_patterns:
+      - Code scope: default='compact' (file content can be 100KB+)
+      - Symbols/decisions/patterns/failures: default='full' (structured, small)
+      - Explicit warning in description: "WARNING: 'full' + code scope = large results"
+
   consolidate_multi_scope_search:
     when: Reducing API surface by consolidating multiple search tools into unified multi-scope tool
     approach: |
       1. Define unified search tool with scope array: ["code", "symbols", "decisions", "patterns", "failures"]
       2. Implement normalizeFilters(): silently drop invalid filters, resolve repository
       3. Execute scopes in parallel via Promise.all()
-      4. Support output formats: full, paths, compact
+      4. Support output formats: full, paths, compact, snippet
     timestamp: 2026-02-03
     evidence: app/src/mcp/tools.ts (lines 104-1278)
     key_patterns:
@@ -192,6 +223,48 @@ patterns:
     timestamp: 2026-02-04
     evidence: .claude/hooks/kotadb/agent-context.py lines 179-240
 
+  snippet_extraction_pattern:
+    structure: |
+      export function extractLineSnippets(content, query, contextLines): SnippetMatch[] {
+        const lines = content.split("\n");
+        const lowerQuery = query.toLowerCase();
+        const matches: SnippetMatch[] = [];
+        
+        lines.forEach((line, index) => {
+          if (line.toLowerCase().includes(lowerQuery)) {
+            const start = Math.max(0, index - contextLines);
+            const end = Math.min(lines.length, index + contextLines + 1);
+            matches.push({
+              line: index + 1,  // 1-indexed
+              content: line,
+              context_before: lines.slice(start, index),
+              context_after: lines.slice(index + 1, end)
+            });
+          }
+        });
+        return matches;
+      }
+    timestamp: 2026-02-04
+    evidence: app/src/api/queries.ts lines 1486-1514, app/src/api/__tests__/queries-sqlite.test.ts
+
+  output_mode_size_guidance_pattern:
+    structure: |
+      Tool description template:
+      """
+      OUTPUT MODES:
+      - 'paths': File paths only (~100 bytes/result)
+      - 'compact': Summary info (~200 bytes/result) - DEFAULT for code scope
+      - 'snippet': Matching lines with context (~2KB/result)
+      - 'full': Complete content (~100KB/result) - Use with caution for code scope
+      
+      TIPS:
+      - Use 'snippet' for code exploration (shows matches in context)
+      - Use 'compact' for quick file discovery
+      - Use 'full' only for small result sets (symbols, decisions, etc.)
+      """
+    timestamp: 2026-02-04
+    evidence: app/src/mcp/tools.ts SEARCH_TOOL description
+
   multi_scope_search_pattern:
     structure: |
       async function executeSearch(params) {
@@ -211,20 +284,23 @@ best_practices:
 
   mcp: |
     - Tool descriptions explain when/why
-    - Validate all parameters
+    - Validate all parameters with clear error messages
     - Add contextual tips for education
     - forceStderr: true in stdio mode
+    - Document output modes with size guidance
 
   queries: |
     - Internal functions: db param (testable)
     - Public functions: getGlobalDatabase()
     - Safe table counting for optional tables
     - escapeFts5Term() for user input
+    - Export utility functions for reuse (extractLineSnippets)
 
   testing: |
     - Parameter validation + edge cases
     - KOTADB_PATH for integration tests
     - Document private functions via tests (not unit testing internals)
+    - Test boundary conditions (file start/end for snippets)
 
   hooks: |
     - Always provide capability context (not file-dependent)
@@ -252,29 +328,28 @@ stability:
   convergence_indicators:
     insight_rate_trend: stable_to_increasing
     contradiction_count: 0
-    new_patterns_added_this_cycle: 3
-    new_operations_added_this_cycle: 3
+    new_patterns_added_this_cycle: 5
+    new_operations_added_this_cycle: 5
     last_reviewed: 2026-02-04
     utility_ratio: 1.0
     notes: |
-      Eleventh cycle - MCP tool UX enhancements (search tips + statistics + hook):
+      Twelfth cycle - Snippet output mode and scope-aware defaults (uncommitted):
       
-      New operations: add_contextual_search_tips, add_statistics_tool, extend_hook_with_capability_context
-      New patterns: contextual_search_tips_pattern, safe_table_counting_pattern, hook_context_combination_pattern
+      New operations: implement_snippet_output_mode, scope_specific_output_defaults
+      New patterns: snippet_extraction_pattern, output_mode_size_guidance_pattern
       
       Key learnings:
-      - Static pattern matching (<1ms) sufficient for contextual tips
-      - Safe table counting enables schema evolution compatibility
-      - Capability context at startup reduces "how do I..." questions
-      - MODERATE tip frequency balances education with avoiding noise
+      - Line-based snippet extraction with configurable context (0-10 lines)
+      - Output mode hierarchy based on payload size: paths < compact < snippet < full
+      - Scope-specific defaults prevent large responses (code defaults to 'compact')
+      - Graceful degradation: non-code scopes fall back to compact in snippet mode
+      - Clear size guidance in tool descriptions improves LLM decision-making
       
-      Size governance executed:
-      - Previous: 797 lines
-      - Before cleanup: 1115 lines (+318)
-      - After condensing verbose sections: ~400 lines
-      - Removed: Redundant pitfalls (referenced from operations instead)
-      - Removed: Pattern code duplication (reference operations)
-      - Status: Within 600-800 line target, room for growth
+      Size governance:
+      - Previous: 280 lines
+      - After update: ~365 lines
+      - Status: Well within 600-800 line target, room for growth
       
-      Architecture: High stability, zero contradictions across 11 cycles
-      Next review: After 10-15 API commits or new patterns
+      Architecture: High stability, zero contradictions across 12 cycles
+      Pattern evolution: MCP tool UX continues to mature (tips + statistics + snippets)
+      Next review: After next significant API pattern emerges

--- a/app/tests/mcp/search-snippet-mode.integration.test.ts
+++ b/app/tests/mcp/search-snippet-mode.integration.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Integration tests for unified search tool - snippet output mode
+ * 
+ * Tests the snippet output mode feature added in issue #152.
+ * Follows antimocking philosophy - no mocks, real database operations.
+ * 
+ * @module tests/mcp/search-snippet-mode.integration
+ */
+
+import { describe, expect, test, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { executeSearch } from "@mcp/tools.js";
+import { closeGlobalConnections, getGlobalDatabase } from "@db/sqlite/index.js";
+import type { KotaDatabase } from "@db/sqlite/sqlite-client.js";
+import { 
+  createTempDir, 
+  cleanupTempDir, 
+} from "../helpers/db.js";
+
+describe("Unified search - snippet output mode", () => {
+  let tempDir: string;
+  let dbPath: string;
+  let db: KotaDatabase;
+  let originalDbPath: string | undefined;
+  let repoId: string;
+  const requestId = "test-request";
+  const userId = "test-user";
+  
+  beforeAll(() => {
+    // Create temp directory for file-based database
+    tempDir = createTempDir("search-snippet-test-");
+    dbPath = join(tempDir, "test.db");
+    
+    // Save original and set test database path
+    originalDbPath = process.env.KOTADB_PATH;
+    process.env.KOTADB_PATH = dbPath;
+    
+    // Clear any existing global connections
+    closeGlobalConnections();
+  });
+  
+  afterAll(() => {
+    // Restore original database path
+    if (originalDbPath !== undefined) {
+      process.env.KOTADB_PATH = originalDbPath;
+    } else {
+      delete process.env.KOTADB_PATH;
+    }
+    
+    // Clean up connections and temp directory
+    closeGlobalConnections();
+    cleanupTempDir(tempDir);
+  });
+  
+  beforeEach(() => {
+    // Get global database (will use KOTADB_PATH)
+    db = getGlobalDatabase();
+    
+    // Create test repository directly
+    repoId = randomUUID();
+    db.run(
+      `INSERT INTO repositories (id, name, full_name, default_branch)
+       VALUES (?, ?, ?, ?)`,
+      [repoId, "snippet-test-repo", "test-org/snippet-test-repo", "main"]
+    );
+    
+    // Seed test file with multi-line content
+    const fileId = randomUUID();
+    const testContent = [
+      "// File header",
+      "import { KotaDatabase } from '@db/sqlite';",
+      "",
+      "export function authenticate(user: string) {",
+      "  // Authentication logic here",
+      "  return checkCredentials(user);",
+      "}",
+      "",
+      "export function authorize(user: string, resource: string) {",
+      "  // Authorization logic",
+      "  if (!authenticate(user)) {",
+      "    return false;",
+      "  }",
+      "  return checkPermissions(user, resource);",
+      "}",
+    ].join('\n');
+    
+    db.run(
+      `INSERT INTO indexed_files (id, repository_id, path, content, language, indexed_at, content_hash)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      [
+        fileId,
+        repoId,
+        "src/auth.ts",
+        testContent,
+        "typescript",
+        new Date().toISOString(),
+        randomUUID(),
+      ]
+    );
+  });
+  
+  afterEach(() => {
+    // Clean up test data
+    if (db) {
+      db.run("DELETE FROM indexed_files WHERE repository_id = ?", [repoId]);
+      db.run("DELETE FROM repositories WHERE id = ?", [repoId]);
+    }
+  });
+  
+  test("should return snippets with matches and context for code scope", async () => {
+    const result = await executeSearch(
+      {
+        query: "authenticate",
+        scope: ["code"],
+        output: "snippet",
+        context_lines: 2,
+        filters: { repository: repoId }
+      },
+      requestId,
+      userId
+    ) as any;
+    
+    expect(result.results.code).toBeDefined();
+    expect(Array.isArray(result.results.code)).toBe(true);
+    expect(result.results.code.length).toBeGreaterThan(0);
+    
+    const firstResult = result.results.code[0];
+    expect(firstResult.path).toBe("src/auth.ts");
+    expect(firstResult.matches).toBeDefined();
+    expect(Array.isArray(firstResult.matches)).toBe(true);
+    
+    // Should have 2 matches (line 4 and line 11)
+    expect(firstResult.matches.length).toBeGreaterThanOrEqual(2);
+    
+    const firstMatch = firstResult.matches[0];
+    expect(firstMatch.line).toBeDefined();
+    expect(firstMatch.content).toContain("authenticate");
+    expect(Array.isArray(firstMatch.context_before)).toBe(true);
+    expect(Array.isArray(firstMatch.context_after)).toBe(true);
+  });
+  
+  test("should respect context_lines parameter", async () => {
+    const result = await executeSearch(
+      {
+        query: "authenticate",
+        scope: ["code"],
+        output: "snippet",
+        context_lines: 1,
+        filters: { repository: repoId }
+      },
+      requestId,
+      userId
+    ) as any;
+    
+    const firstMatch = result.results.code[0]?.matches[0];
+    expect(firstMatch.context_before.length).toBeLessThanOrEqual(1);
+    expect(firstMatch.context_after.length).toBeLessThanOrEqual(1);
+  });
+  
+  test("should default to 3 lines of context when context_lines not specified", async () => {
+    const result = await executeSearch(
+      {
+        query: "authenticate",
+        scope: ["code"],
+        output: "snippet",
+        filters: { repository: repoId }
+      },
+      requestId,
+      userId
+    ) as any;
+    
+    const firstMatch = result.results.code[0]?.matches[0];
+    // Default is 3 lines, but may be less at file boundaries
+    expect(firstMatch.context_before.length).toBeLessThanOrEqual(3);
+    expect(firstMatch.context_after.length).toBeLessThanOrEqual(3);
+  });
+  
+  test("should default to compact output for code scope when output not specified", async () => {
+    const result = await executeSearch(
+      {
+        query: "authenticate",
+        scope: ["code"],
+        filters: { repository: repoId }
+      },
+      requestId,
+      userId
+    ) as any;
+    
+    // Default should be compact for code scope
+    expect(result.results.code).toBeDefined();
+    const firstResult = result.results.code[0];
+    expect(firstResult.path).toBeDefined();
+    expect(firstResult.match_count).toBeDefined();
+    // Should NOT have full content field
+    expect(firstResult.content).toBeUndefined();
+    // Should NOT have matches field (that's snippet mode)
+    expect(firstResult.matches).toBeUndefined();
+  });
+  
+  test("should validate context_lines parameter range", async () => {
+    // Test invalid context_lines (too high)
+    await expect(
+      executeSearch(
+        {
+          query: "authenticate",
+          scope: ["code"],
+          output: "snippet",
+          context_lines: 11,  // Max is 10
+          filters: { repository: repoId }
+        },
+        requestId,
+        userId
+      )
+    ).rejects.toThrow("context_lines' must be between 0 and 10");
+  });
+  
+  test("should validate context_lines type", async () => {
+    await expect(
+      executeSearch(
+        {
+          query: "authenticate",
+          scope: ["code"],
+          output: "snippet",
+          context_lines: "invalid",  // Should be number
+          filters: { repository: repoId }
+        },
+        requestId,
+        userId
+      )
+    ).rejects.toThrow("context_lines' must be a number");
+  });
+  
+  test("should validate output parameter includes snippet", async () => {
+    // Just verify snippet is a valid output option (no error)
+    const result = await executeSearch(
+      {
+        query: "authenticate",
+        scope: ["code"],
+        output: "snippet",
+        filters: { repository: repoId }
+      },
+      requestId,
+      userId
+    ) as any;
+    
+    expect(result.results).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Add a new `snippet` output mode to the unified search MCP tool that returns matching lines with configurable context, reducing result sizes from ~100KB to ~2KB while preserving useful match context.

### Changes
- Add `snippet` output mode with line-based match extraction
- Add `context_lines` parameter (0-10, default: 3)
- Change code scope default output to `compact` (prevents 100KB+ responses)
- Add `extractLineSnippets()` utility function to queries.ts
- Update tool description with output mode size guidance
- Add 11 unit tests and 7 integration tests

### Output Mode Comparison

| Mode | Code Results | Size |
|------|--------------|------|
| `paths` | File paths only | ~100 bytes |
| `compact` | Paths + match_count | ~200 bytes |
| `snippet` (new) | Paths + matching lines with context | ~2KB |
| `full` | Paths + entire file content | ~100KB |

### Example Usage

```json
{
  "query": "authenticate",
  "scope": ["code"],
  "output": "snippet",
  "context_lines": 3
}
```

## Validation Evidence

### Validation Level: 2
**Justification**: Feature with new MCP tool output mode and query layer changes

**Commands Run**:
- ✅ `bun run lint` - Checked 165 files, no issues
- ✅ `bun run typecheck` - No errors
- ✅ `bun test --filter snippet` - 7 tests passed

**Real-Service Evidence**:
- SQLite integration tests: All snippet extraction tests use real SQLite database
- Test coverage: 11 unit tests + 7 integration tests for snippet functionality

## Anti-Mock Compliance

No new mocks introduced. All tests use real SQLite databases with test fixtures.

Closes #152