### PR TITLE
feat(automation): batch execution, resilience, and observability (#185)

### DIFF
--- a/.github/workflows/adw-trigger.yml
+++ b/.github/workflows/adw-trigger.yml
@@ -1,0 +1,73 @@
+name: ADW - Automated Development Workflow
+
+# Trigger when a label is added to an issue
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  issues: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  automation:
+    # Only run for automation trigger labels
+    if: >
+      github.event.label.name == 'auto:implement' ||
+      github.event.label.name == 'auto:review'
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    # Prevent duplicate runs for the same issue
+    concurrency:
+      group: adw-issue-${{ github.event.issue.number }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full history for worktree support
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.1.29
+
+      - name: Install dependencies
+        run: cd automation && bun install --frozen-lockfile
+
+      - name: Run ADW
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd automation
+          bun run src/index.ts ${{ github.event.issue.number }} --no-comment
+
+      - name: Post success comment
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.payload.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '✅ ADW automation completed successfully for this issue.'
+            })
+
+      - name: Post failure comment
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            github.rest.issues.createComment({
+              issue_number: context.payload.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `❌ ADW automation failed. Check the [workflow run](${runUrl}) for details.`
+            })

--- a/automation/src/batch.ts
+++ b/automation/src/batch.ts
@@ -1,0 +1,327 @@
+/**
+ * Batch runner for concurrent multi-issue workflow execution
+ * Uses a semaphore pattern for concurrency control (no external deps)
+ */
+import { runWorkflow } from "./workflow.ts";
+import {
+  createWorktree,
+  formatWorktreeTimestamp,
+  type WorktreeInfo,
+} from "./worktree.ts";
+
+export interface BatchOptions {
+  concurrency: number; // default: 3
+  failFast: boolean; // default: false (continue-on-error)
+  dryRun: boolean;
+  verbose: boolean;
+  accumulateContext: boolean;
+  skipComment: boolean;
+}
+
+export interface BatchIssueResult {
+  issueNumber: number;
+  success: boolean;
+  prUrl?: string;
+  error?: string;
+  durationMs: number;
+  costUsd: number;
+}
+
+export interface BatchResult {
+  results: BatchIssueResult[];
+  totalDurationMs: number;
+  totalCostUsd: number;
+  successCount: number;
+  failureCount: number;
+}
+
+/**
+ * Simple semaphore for concurrency limiting
+ * No external dependencies — just a queue + counter
+ */
+class Semaphore {
+  private queue: Array<() => void> = [];
+  private running = 0;
+
+  constructor(private max: number) {}
+
+  async acquire(): Promise<void> {
+    if (this.running < this.max) {
+      this.running++;
+      return;
+    }
+    return new Promise<void>((resolve) => {
+      this.queue.push(() => {
+        this.running++;
+        resolve();
+      });
+    });
+  }
+
+  release(): void {
+    this.running--;
+    const next = this.queue.shift();
+    if (next) {
+      next();
+    }
+  }
+}
+
+/**
+ * Run multiple issues concurrently with concurrency limiting
+ */
+export async function runBatch(
+  issues: number[],
+  options: BatchOptions,
+  projectRoot: string
+): Promise<BatchResult> {
+  const batchStart = performance.now();
+  const semaphore = new Semaphore(options.concurrency);
+  let cancelled = false;
+
+  process.stderr.write(
+    `[batch] Starting batch run: ${issues.length} issues, concurrency=${options.concurrency}\n`
+  );
+
+  const tasks = issues.map((issueNumber) => {
+    return async (): Promise<BatchIssueResult> => {
+      if (cancelled) {
+        return {
+          issueNumber,
+          success: false,
+          error: "Cancelled (fail-fast)",
+          durationMs: 0,
+          costUsd: 0,
+        };
+      }
+
+      await semaphore.acquire();
+      const issueStart = performance.now();
+
+      try {
+        if (cancelled) {
+          return {
+            issueNumber,
+            success: false,
+            error: "Cancelled (fail-fast)",
+            durationMs: 0,
+            costUsd: 0,
+          };
+        }
+
+        process.stderr.write(`[batch] Starting issue #${issueNumber}\n`);
+
+        // Each issue gets its own worktree
+        let worktreeInfo: WorktreeInfo | null = null;
+        if (!options.dryRun) {
+          try {
+            const timestamp = formatWorktreeTimestamp(new Date());
+            worktreeInfo = await createWorktree({
+              issueNumber,
+              projectRoot,
+              baseBranch: "develop",
+              timestamp,
+            });
+          } catch (error) {
+            process.stderr.write(
+              `[batch] Warning: Failed to create worktree for #${issueNumber}: ${error}\n`
+            );
+          }
+        }
+
+        const result = await runWorkflow({
+          issueNumber,
+          dryRun: options.dryRun,
+          verbose: options.verbose,
+          accumulateContext: options.accumulateContext,
+          workingDirectory: worktreeInfo?.path ?? projectRoot,
+          mainProjectRoot: projectRoot,
+          branchName: worktreeInfo?.branch,
+        });
+
+        const durationMs = Math.round(performance.now() - issueStart);
+
+        const issueResult: BatchIssueResult = {
+          issueNumber,
+          success: result.success,
+          prUrl: result.prUrl ?? undefined,
+          error: result.errorMessage ?? undefined,
+          durationMs,
+          costUsd: result.totalCostUsd,
+        };
+
+        process.stderr.write(
+          `[batch] Completed issue #${issueNumber}: ${result.success ? "SUCCESS" : "FAILED"}\n`
+        );
+
+        if (options.failFast && !result.success) {
+          cancelled = true;
+        }
+
+        return issueResult;
+      } catch (error) {
+        const durationMs = Math.round(performance.now() - issueStart);
+        const errorMsg =
+          error instanceof Error ? error.message : String(error);
+
+        process.stderr.write(
+          `[batch] Issue #${issueNumber} threw: ${errorMsg}\n`
+        );
+
+        if (options.failFast) {
+          cancelled = true;
+        }
+
+        return {
+          issueNumber,
+          success: false,
+          error: errorMsg,
+          durationMs,
+          costUsd: 0,
+        };
+      } finally {
+        semaphore.release();
+      }
+    };
+  });
+
+  // Run all tasks with Promise.allSettled for independent failure handling
+  const settled = await Promise.allSettled(tasks.map((t) => t()));
+
+  const results: BatchIssueResult[] = settled.map((s) => {
+    if (s.status === "fulfilled") {
+      return s.value;
+    }
+    // Should not happen since we catch within tasks, but handle gracefully
+    return {
+      issueNumber: 0,
+      success: false,
+      error: s.reason instanceof Error ? s.reason.message : String(s.reason),
+      durationMs: 0,
+      costUsd: 0,
+    };
+  });
+
+  const totalDurationMs = Math.round(performance.now() - batchStart);
+  const totalCostUsd = results.reduce((sum, r) => sum + r.costUsd, 0);
+  const successCount = results.filter((r) => r.success).length;
+  const failureCount = results.filter((r) => !r.success).length;
+
+  return {
+    results,
+    totalDurationMs,
+    totalCostUsd,
+    successCount,
+    failureCount,
+  };
+}
+
+/**
+ * Discover issues with a specific label via gh CLI
+ */
+export async function discoverIssuesByLabel(
+  label: string
+): Promise<number[]> {
+  const proc = Bun.spawn(
+    [
+      "gh",
+      "issue",
+      "list",
+      "--label",
+      label,
+      "--state",
+      "open",
+      "--json",
+      "number",
+      "--limit",
+      "50",
+    ],
+    {
+      stdout: "pipe",
+      stderr: "pipe",
+    }
+  );
+
+  const output = await new Response(proc.stdout).text();
+  const exitCode = await proc.exited;
+
+  if (exitCode !== 0) {
+    const stderr = await new Response(proc.stderr).text();
+    throw new Error(
+      `Failed to discover issues with label "${label}": ${stderr}`
+    );
+  }
+
+  const parsed = JSON.parse(output) as Array<{ number: number }>;
+  return parsed.map((item) => item.number).sort((a, b) => a - b);
+}
+
+/**
+ * Format batch results as summary table
+ */
+export function formatBatchSummary(result: BatchResult): string {
+  const lines: string[] = [];
+
+  lines.push("");
+  lines.push("=== Batch Execution Summary ===");
+  lines.push("");
+
+  // Header
+  const header = padRight("Issue", 10) +
+    padRight("Status", 10) +
+    padRight("Duration", 14) +
+    padRight("Cost", 12) +
+    "PR";
+  lines.push(header);
+  lines.push("-".repeat(70));
+
+  // Per-issue rows
+  for (const r of result.results) {
+    const status = r.success ? "OK" : "FAIL";
+    const duration = formatDuration(r.durationMs);
+    const cost = `$${r.costUsd.toFixed(4)}`;
+    const pr = r.prUrl ?? (r.error ? `err: ${truncate(r.error, 30)}` : "-");
+
+    lines.push(
+      padRight(`#${r.issueNumber}`, 10) +
+        padRight(status, 10) +
+        padRight(duration, 14) +
+        padRight(cost, 12) +
+        pr
+    );
+  }
+
+  // Totals
+  lines.push("-".repeat(70));
+  const totalDuration = formatDuration(result.totalDurationMs);
+  const totalCost = `$${result.totalCostUsd.toFixed(4)}`;
+  lines.push(
+    padRight("TOTAL", 10) +
+      padRight(`${result.successCount}ok/${result.failureCount}fail`, 10) +
+      padRight(totalDuration, 14) +
+      padRight(totalCost, 12)
+  );
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+function formatDuration(ms: number): string {
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  return `${minutes}m ${remainingSeconds}s`;
+}
+
+function padRight(str: string, width: number): string {
+  if (str.length >= width) return str;
+  return str + " ".repeat(width - str.length);
+}
+
+function truncate(str: string, maxLen: number): string {
+  if (str.length <= maxLen) return str;
+  return str.substring(0, maxLen - 3) + "...";
+}

--- a/automation/src/checkpoint.ts
+++ b/automation/src/checkpoint.ts
@@ -1,0 +1,112 @@
+/**
+ * Checkpoint module for workflow resume support
+ * Stores checkpoint data at automation/.data/checkpoints/{issueNumber}.json
+ * Uses atomic writes (write .tmp then rename) for safety
+ */
+import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const CHECKPOINT_DIR = join(
+  import.meta.dir,
+  "..",
+  ".data",
+  "checkpoints"
+);
+
+export interface CheckpointData {
+  issueNumber: number;
+  workflowId: string | null;
+  completedPhases: string[];
+  domain: string;
+  specPath: string | null;
+  filesModified: string[];
+  worktreePath: string | null;
+  branchName: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * Ensure checkpoint directory exists
+ */
+function ensureDir(): void {
+  if (!existsSync(CHECKPOINT_DIR)) {
+    mkdirSync(CHECKPOINT_DIR, { recursive: true });
+  }
+}
+
+/**
+ * Get checkpoint file path for an issue
+ */
+function checkpointPath(issueNumber: number): string {
+  return join(CHECKPOINT_DIR, `${issueNumber}.json`);
+}
+
+/**
+ * Write checkpoint data atomically (write .tmp then rename)
+ */
+export function writeCheckpoint(data: CheckpointData): void {
+  ensureDir();
+  const filePath = checkpointPath(data.issueNumber);
+  const tmpPath = `${filePath}.tmp`;
+
+  const payload = JSON.stringify(data, null, 2);
+  writeFileSync(tmpPath, payload, "utf-8");
+  renameSync(tmpPath, filePath);
+}
+
+/**
+ * Read the latest checkpoint for an issue, or null if none exists
+ */
+export function readLatestCheckpoint(
+  issueNumber: number
+): CheckpointData | null {
+  const filePath = checkpointPath(issueNumber);
+  if (!existsSync(filePath)) {
+    return null;
+  }
+
+  try {
+    const text = readFileSync(filePath, "utf-8");
+    return JSON.parse(text) as CheckpointData;
+  } catch {
+    process.stderr.write(
+      `[checkpoint] Warning: Failed to read checkpoint for issue #${issueNumber}\n`
+    );
+    return null;
+  }
+}
+
+/**
+ * Clear (delete) checkpoint for an issue
+ */
+export function clearCheckpoint(issueNumber: number): void {
+  const filePath = checkpointPath(issueNumber);
+  if (existsSync(filePath)) {
+    unlinkSync(filePath);
+  }
+}
+
+/**
+ * List all active checkpoints
+ */
+export function listCheckpoints(): CheckpointData[] {
+  ensureDir();
+  const checkpoints: CheckpointData[] = [];
+
+  const files = readdirSync(CHECKPOINT_DIR).filter((f) =>
+    f.endsWith(".json")
+  );
+
+  for (const file of files) {
+    try {
+      const filePath = join(CHECKPOINT_DIR, file);
+      const text = readFileSync(filePath, "utf-8");
+      checkpoints.push(JSON.parse(text) as CheckpointData);
+    } catch {
+      // Skip invalid checkpoint files
+    }
+  }
+
+  return checkpoints;
+}

--- a/automation/src/index.ts
+++ b/automation/src/index.ts
@@ -45,6 +45,13 @@ import {
   formatWorktreeTimestamp,
   type WorktreeInfo 
 } from "./worktree.ts";
+import { readLatestCheckpoint } from "./checkpoint.ts";
+import {
+  runBatch,
+  discoverIssuesByLabel,
+  formatBatchSummary,
+  type BatchOptions,
+} from "./batch.ts";
 
 function parseIssueNumber(arg: string): number | null {
   // Support #123 or 123 format
@@ -58,23 +65,41 @@ KotaDB Automation
 
 Usage:
   bun run src/index.ts <issue> [options]
+  bun run src/index.ts --batch <issues...> [options]
+  bun run src/index.ts --batch-label <label> [options]
+  bun run src/index.ts --resume <issue> [options]
+  bun run src/index.ts --status
+  bun run src/index.ts --metrics
 
 Arguments:
-  <issue>          GitHub issue number (#123 or 123)
+  <issue>                GitHub issue number (#123 or 123)
 
-Options:
+Single-Issue Options:
   --dry-run              Preview workflow without executing changes
-  --metrics              Display recent workflow metrics
   --no-comment           Skip posting GitHub comment
   --verbose, -v          Enable detailed action-level logging
   --accumulate-context   Enable context accumulation for inter-phase handoffs
+
+Batch Options:
+  --batch <issues...>    Run multiple issues concurrently (#123 #124 or 123 124)
+  --batch-label <label>  Discover and run all open issues with the given label
+  --concurrency <n>      Max parallel issues (default: 3, used with --batch/--batch-label)
+
+Resume Options:
+  --resume <issue>       Resume a previously failed issue from its latest checkpoint
+
+Status & Metrics:
+  --status               Display run manifest (recent batch/run status)
+  --metrics              Display recent workflow metrics
   --help                 Show this help message
 
 Examples:
   bun run src/index.ts #123
-  bun run src/index.ts 123 --dry-run
-  bun run src/index.ts 123 --verbose
-  bun run src/index.ts 123 --accumulate-context
+  bun run src/index.ts 123 --dry-run --verbose
+  bun run src/index.ts --batch 123 124 125 --concurrency 2
+  bun run src/index.ts --batch-label auto:implement
+  bun run src/index.ts --resume 123
+  bun run src/index.ts --status
   bun run src/index.ts --metrics
 `);
 }
@@ -104,6 +129,302 @@ function printMetrics(): void {
   process.stdout.write("-".repeat(80) + "\n");
 }
 
+async function printStatus(): Promise<void> {
+  try {
+    const { readManifest, formatManifestTable } = await import("./manifest.ts");
+    const entries = readManifest(projectRoot);
+    if (entries.length === 0) {
+      process.stdout.write("No run manifest found.\n");
+      return;
+    }
+    process.stdout.write(formatManifestTable(entries));
+  } catch {
+    process.stderr.write("Warning: manifest module not available yet.\n");
+  }
+}
+/**
+ * Extract a string value following a flag in args
+ */
+function getFlagValue(args: string[], flag: string): string | null {
+  const idx = args.indexOf(flag);
+  if (idx === -1 || idx + 1 >= args.length) return null;
+  const val = args[idx + 1];
+  if (!val || val.startsWith("--")) return null;
+  return val;
+}
+
+/**
+ * Extract a numeric value following a flag in args
+ */
+function getFlagNumericValue(args: string[], flag: string): number | null {
+  const val = getFlagValue(args, flag);
+  if (val === null) return null;
+  const num = parseInt(val, 10);
+  return isNaN(num) ? null : num;
+}
+
+/**
+ * Collect all issue numbers after --batch flag until next flag or end
+ */
+function collectBatchIssues(args: string[]): number[] {
+  const batchIdx = args.indexOf("--batch");
+  if (batchIdx === -1) return [];
+
+  const issues: number[] = [];
+  for (let i = batchIdx + 1; i < args.length; i++) {
+    const arg = args[i]!;
+    if (arg.startsWith("--")) break;
+    const num = parseIssueNumber(arg);
+    if (num !== null) {
+      issues.push(num);
+    }
+  }
+  return issues;
+}
+
+async function handleBatch(args: string[]): Promise<number> {
+  const dryRun = args.includes("--dry-run");
+  const verbose = args.includes("--verbose") || args.includes("-v");
+  const accumulateContext = args.includes("--accumulate-context");
+  const skipComment = args.includes("--no-comment");
+  const concurrency = getFlagNumericValue(args, "--concurrency") ?? 3;
+
+  let issues: number[] = [];
+
+  if (args.includes("--batch-label")) {
+    const label = getFlagValue(args, "--batch-label");
+    if (!label) {
+      process.stderr.write("Error: --batch-label requires a label value\n");
+      return 1;
+    }
+    process.stdout.write(`Discovering issues with label "${label}"...\n`);
+    issues = await discoverIssuesByLabel(label);
+    if (issues.length === 0) {
+      process.stdout.write(`No open issues found with label "${label}"\n`);
+      return 0;
+    }
+    process.stdout.write(`Found ${issues.length} issues: ${issues.map(n => `#${n}`).join(", ")}\n`);
+  } else {
+    issues = collectBatchIssues(args);
+    if (issues.length === 0) {
+      process.stderr.write("Error: --batch requires at least one issue number\n");
+      return 1;
+    }
+  }
+
+  const options: BatchOptions = {
+    concurrency,
+    failFast: false,
+    dryRun,
+    verbose,
+    accumulateContext,
+    skipComment,
+  };
+
+  const result = await runBatch(issues, options, projectRoot);
+
+  // Print summary
+  process.stdout.write(formatBatchSummary(result));
+
+  // Record individual metrics
+  for (const r of result.results) {
+    const metrics: WorkflowMetrics = {
+      issue_number: r.issueNumber,
+      started_at: new Date().toISOString(),
+      completed_at: new Date().toISOString(),
+      success: r.success,
+      duration_ms: r.durationMs,
+      input_tokens: 0,
+      output_tokens: 0,
+      total_cost_usd: r.costUsd,
+      pr_url: r.prUrl ?? null,
+      error_message: r.error ?? null,
+      session_id: null,
+    };
+    recordMetrics(metrics);
+  }
+
+  closeMetricsDb();
+  return result.failureCount > 0 ? 1 : 0;
+}
+
+async function handleResume(args: string[]): Promise<number> {
+  const resumeArg = getFlagValue(args, "--resume");
+  if (!resumeArg) {
+    process.stderr.write("Error: --resume requires an issue number\n");
+    return 1;
+  }
+
+  const issueNumber = parseIssueNumber(resumeArg);
+  if (issueNumber === null) {
+    process.stderr.write(`Error: Invalid issue number: ${resumeArg}\n`);
+    return 1;
+  }
+
+  const checkpoint = readLatestCheckpoint(issueNumber);
+  if (!checkpoint) {
+    process.stderr.write(
+      `No checkpoint found for issue #${issueNumber}. Starting fresh.\n`
+    );
+  } else {
+    process.stdout.write(
+      `Resuming issue #${issueNumber} from checkpoint\n`
+    );
+    process.stdout.write(
+      `  Domain: ${checkpoint.domain}\n`
+    );
+    process.stdout.write(
+      `  Completed phases: ${checkpoint.completedPhases.join(", ") || "none"}\n`
+    );
+    if (checkpoint.worktreePath) {
+      process.stdout.write(
+        `  Worktree: ${checkpoint.worktreePath}\n`
+      );
+    }
+  }
+
+  // Determine next phase from checkpoint
+  const phaseOrder = ["analysis", "plan", "build", "improve", "pr"];
+  let resumeFromPhase: string | undefined;
+  if (checkpoint) {
+    const lastCompleted = checkpoint.completedPhases[checkpoint.completedPhases.length - 1];
+    if (lastCompleted) {
+      const lastIdx = phaseOrder.indexOf(lastCompleted);
+      if (lastIdx >= 0 && lastIdx + 1 < phaseOrder.length) {
+        resumeFromPhase = phaseOrder[lastIdx + 1];
+      }
+    }
+  }
+
+  const dryRun = args.includes("--dry-run");
+  const verbose = args.includes("--verbose") || args.includes("-v");
+  const accumulateContext = args.includes("--accumulate-context");
+  const skipComment = args.includes("--no-comment");
+
+  // Use worktree from checkpoint if available, otherwise create new
+  let worktreeInfo: WorktreeInfo | null = null;
+  if (checkpoint?.worktreePath && existsSync(checkpoint.worktreePath)) {
+    worktreeInfo = {
+      path: checkpoint.worktreePath,
+      branch: checkpoint.branchName ?? `automation/${issueNumber}-resumed`,
+      created: false,
+    };
+  } else if (!dryRun) {
+    try {
+      const timestamp = formatWorktreeTimestamp(new Date());
+      worktreeInfo = await createWorktree({
+        issueNumber,
+        projectRoot,
+        baseBranch: "develop",
+        timestamp,
+      });
+    } catch (error) {
+      process.stderr.write(`Failed to create worktree: ${error}\n`);
+    }
+  }
+
+  process.stdout.write(
+    `Starting workflow for issue #${issueNumber}${resumeFromPhase ? ` (resuming from ${resumeFromPhase})` : ""}${dryRun ? " (dry run)" : ""}\n`
+  );
+
+  const startedAt = new Date().toISOString();
+  const startTime = performance.now();
+
+  try {
+    const result = await runWorkflow({
+      issueNumber,
+      dryRun,
+      verbose,
+      accumulateContext,
+      workingDirectory: worktreeInfo?.path ?? projectRoot,
+      mainProjectRoot: projectRoot,
+      branchName: worktreeInfo?.branch,
+      resumeFromPhase,
+      checkpointData: checkpoint ? {
+        domain: checkpoint.domain,
+        specPath: checkpoint.specPath,
+        filesModified: checkpoint.filesModified,
+        completedPhases: checkpoint.completedPhases,
+      } : undefined,
+    });
+
+    const endTime = performance.now();
+    const durationMs = Math.round(endTime - startTime);
+
+    const metrics: WorkflowMetrics = {
+      issue_number: issueNumber,
+      started_at: startedAt,
+      completed_at: new Date().toISOString(),
+      success: result.success,
+      duration_ms: durationMs,
+      input_tokens: result.inputTokens,
+      output_tokens: result.outputTokens,
+      total_cost_usd: result.totalCostUsd,
+      pr_url: result.prUrl,
+      error_message: result.errorMessage,
+      session_id: result.sessionId,
+    };
+
+    recordMetrics(metrics);
+
+    // Post GitHub comment unless skipped or dry run
+    if (!skipComment && !dryRun) {
+      try {
+        await postIssueComment({
+          issueNumber,
+          success: result.success,
+          durationMs,
+          inputTokens: result.inputTokens,
+          outputTokens: result.outputTokens,
+          totalCostUsd: result.totalCostUsd,
+          prUrl: result.prUrl,
+          errorMessage: result.errorMessage,
+          sessionId: result.sessionId,
+        });
+        process.stdout.write("Posted comment to GitHub issue\n");
+      } catch (commentError) {
+        process.stderr.write(
+          `Warning: Failed to post GitHub comment: ${commentError}\n`
+        );
+      }
+    }
+
+    process.stdout.write("\n--- Workflow Summary ---\n");
+    process.stdout.write(`Status: ${result.success ? "SUCCESS" : "FAILURE"}\n`);
+    process.stdout.write(`Duration: ${(durationMs / 1000).toFixed(1)}s\n`);
+    process.stdout.write(`Cost: $${result.totalCostUsd.toFixed(4)}\n`);
+    if (result.prUrl) {
+      process.stdout.write(`PR: ${result.prUrl}\n`);
+    }
+
+    closeMetricsDb();
+    return result.success ? 0 : 1;
+  } catch (error) {
+    const endTime = performance.now();
+    const durationMs = Math.round(endTime - startTime);
+    const errorMessage = error instanceof Error ? error.message : String(error);
+
+    const metrics: WorkflowMetrics = {
+      issue_number: issueNumber,
+      started_at: startedAt,
+      completed_at: new Date().toISOString(),
+      success: false,
+      duration_ms: durationMs,
+      input_tokens: 0,
+      output_tokens: 0,
+      total_cost_usd: 0,
+      pr_url: null,
+      error_message: errorMessage,
+      session_id: null,
+    };
+
+    recordMetrics(metrics);
+    process.stderr.write(`Workflow failed: ${errorMessage}\n`);
+    closeMetricsDb();
+    return 1;
+  }
+}
+
 async function main(): Promise<number> {
   const args = process.argv.slice(2);
 
@@ -117,6 +438,23 @@ async function main(): Promise<number> {
     closeMetricsDb();
     return 0;
   }
+
+  if (args.includes("--status")) {
+    await printStatus();
+    return 0;
+  }
+
+  // Batch modes
+  if (args.includes("--batch") || args.includes("--batch-label")) {
+    return handleBatch(args);
+  }
+
+  // Resume mode
+  if (args.includes("--resume")) {
+    return handleResume(args);
+  }
+
+  // --- Existing single-issue flow (unchanged) ---
 
   // Find issue number in args
   let issueNumber: number | null = null;

--- a/automation/src/manifest.ts
+++ b/automation/src/manifest.ts
@@ -1,0 +1,235 @@
+/**
+ * Run manifest for automation workflow execution tracking
+ * 
+ * Manages a JSON manifest of workflow runs at automation/.data/manifest.json.
+ * Supports concurrent access via atomic writes (write .tmp, rename).
+ */
+import { existsSync, readFileSync, writeFileSync, renameSync, unlinkSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { mkdirSync } from "node:fs";
+
+export interface ManifestEntry {
+  issueNumber: number;
+  status: "running" | "completed" | "failed" | "cancelled";
+  startedAt: string;
+  completedAt?: string;
+  worktreePath?: string;
+  branch?: string;
+  currentPhase?: string;
+  prUrl?: string;
+  costUsd?: number;
+  durationMs?: number;
+  errorMessage?: string;
+}
+
+function getManifestPath(projectRoot: string): string {
+  return join(projectRoot, "automation", ".data", "manifest.json");
+}
+
+/**
+ * Read manifest from disk, return empty array if not found
+ */
+export function readManifest(projectRoot: string): ManifestEntry[] {
+  const manifestPath = getManifestPath(projectRoot);
+  if (!existsSync(manifestPath)) {
+    return [];
+  }
+
+  try {
+    const raw = readFileSync(manifestPath, "utf-8");
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed as ManifestEntry[];
+  } catch {
+    process.stderr.write(`Warning: Failed to read manifest, returning empty\n`);
+    return [];
+  }
+}
+
+/**
+ * Update or insert a manifest entry (upsert by issueNumber + startedAt)
+ * Uses atomic write (write .tmp, rename) for concurrent safety
+ */
+export function updateManifest(
+  projectRoot: string,
+  entry: Partial<ManifestEntry> & { issueNumber: number; startedAt: string }
+): void {
+  const manifestPath = getManifestPath(projectRoot);
+  const dir = dirname(manifestPath);
+
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+
+  const entries = readManifest(projectRoot);
+
+  // Find existing entry by issueNumber + startedAt
+  const existingIdx = entries.findIndex(
+    (e) => e.issueNumber === entry.issueNumber && e.startedAt === entry.startedAt
+  );
+
+  if (existingIdx >= 0) {
+    // Merge update into existing entry
+    const existing = entries[existingIdx]!;
+    entries[existingIdx] = { ...existing, ...entry };
+  } else {
+    // Insert new entry with defaults
+    entries.push({
+      status: "running",
+      ...entry
+    } as ManifestEntry);
+  }
+
+  // Atomic write: write to .tmp file then rename
+  const tmpPath = manifestPath + ".tmp";
+  try {
+    writeFileSync(tmpPath, JSON.stringify(entries, null, 2) + "\n", {
+      encoding: "utf-8",
+      mode: 0o600
+    });
+    renameSync(tmpPath, manifestPath);
+  } catch (error) {
+    process.stderr.write(`Warning: Failed to write manifest: ${error}\n`);
+    // Clean up tmp file if rename failed
+    try {
+      if (existsSync(tmpPath)) {
+        unlinkSync(tmpPath);
+      }
+    } catch {
+      // Ignore cleanup errors
+    }
+  }
+}
+
+/**
+ * Remove completed/failed runs older than maxAgeDays
+ * Returns the number of entries pruned
+ */
+export function pruneManifest(projectRoot: string, maxAgeDays = 7): number {
+  const entries = readManifest(projectRoot);
+  const cutoff = Date.now() - maxAgeDays * 24 * 60 * 60 * 1000;
+
+  const kept: ManifestEntry[] = [];
+  let pruned = 0;
+
+  for (const entry of entries) {
+    const startedMs = new Date(entry.startedAt).getTime();
+    const isTerminal = entry.status === "completed" || entry.status === "failed" || entry.status === "cancelled";
+
+    if (isTerminal && startedMs < cutoff) {
+      pruned++;
+    } else {
+      kept.push(entry);
+    }
+  }
+
+  if (pruned > 0) {
+    const manifestPath = getManifestPath(projectRoot);
+    const tmpPath = manifestPath + ".tmp";
+    try {
+      writeFileSync(tmpPath, JSON.stringify(kept, null, 2) + "\n", {
+        encoding: "utf-8",
+        mode: 0o600
+      });
+      renameSync(tmpPath, manifestPath);
+    } catch (error) {
+      process.stderr.write(`Warning: Failed to write pruned manifest: ${error}\n`);
+      try {
+        if (existsSync(tmpPath)) {
+          unlinkSync(tmpPath);
+        }
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  }
+
+  return pruned;
+}
+
+/**
+ * Format duration in milliseconds to human-readable string
+ */
+function formatDuration(ms: number | undefined): string {
+  if (ms === undefined) return "-";
+  const seconds = ms / 1000;
+  if (seconds >= 60) {
+    const mins = Math.floor(seconds / 60);
+    const secs = (seconds % 60).toFixed(1);
+    return `${mins}m ${secs}s`;
+  }
+  return `${seconds.toFixed(1)}s`;
+}
+
+/**
+ * Format cost in USD to string with 4 decimal places
+ */
+function formatCost(cost: number | undefined): string {
+  if (cost === undefined) return "-";
+  return `$${cost.toFixed(4)}`;
+}
+
+/**
+ * Pad or truncate a string to fit a column width
+ */
+function padCol(value: string, width: number): string {
+  if (value.length > width) {
+    return value.substring(0, width - 1) + "\u2026";
+  }
+  return value.padEnd(width);
+}
+
+/**
+ * Pretty-print manifest for --status CLI flag
+ * 
+ * Output format:
+ * Issue  | Status    | Phase     | Duration  | Cost    | PR
+ * #123   | completed | pr        | 45.2s     | $0.1234 | https://...
+ */
+export function formatManifestTable(entries: ManifestEntry[]): string {
+  if (entries.length === 0) {
+    return "No workflow runs found.\n";
+  }
+
+  const headers = {
+    issue: 7,
+    status: 10,
+    phase: 10,
+    duration: 10,
+    cost: 9,
+    pr: 40
+  };
+
+  const lines: string[] = [];
+
+  // Header
+  lines.push(
+    `${padCol("Issue", headers.issue)}| ${padCol("Status", headers.status)}| ${padCol("Phase", headers.phase)}| ${padCol("Duration", headers.duration)}| ${padCol("Cost", headers.cost)}| PR`
+  );
+
+  // Separator
+  const sep = `${"-".repeat(headers.issue)}|${"-".repeat(headers.status + 1)}|${"-".repeat(headers.phase + 1)}|${"-".repeat(headers.duration + 1)}|${"-".repeat(headers.cost + 1)}|${"-".repeat(headers.pr + 1)}`;
+  lines.push(sep);
+
+  // Rows (most recent first)
+  const sorted = [...entries].sort(
+    (a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime()
+  );
+
+  for (const entry of sorted) {
+    const issue = `#${entry.issueNumber}`;
+    const status = entry.status;
+    const phase = entry.currentPhase ?? "-";
+    const duration = formatDuration(entry.durationMs);
+    const cost = formatCost(entry.costUsd);
+    const pr = entry.prUrl ?? "-";
+
+    lines.push(
+      `${padCol(issue, headers.issue)}| ${padCol(status, headers.status)}| ${padCol(phase, headers.phase)}| ${padCol(duration, headers.duration)}| ${padCol(cost, headers.cost)}| ${pr}`
+    );
+  }
+
+  return lines.join("\n") + "\n";
+}

--- a/automation/src/retry.ts
+++ b/automation/src/retry.ts
@@ -1,0 +1,111 @@
+/**
+ * Retry utility with exponential backoff for transient failures
+ * Only retries on API timeouts, rate limits, and connection errors
+ */
+
+export interface RetryOptions {
+  maxAttempts?: number;
+  initialDelayMs?: number;
+  maxDelayMs?: number;
+  backoffMultiplier?: number;
+  retryableErrors?: string[];
+}
+
+export interface RetryResult<T> {
+  result: T;
+  attempts: number;
+  totalRetryDelayMs: number;
+}
+
+const DEFAULT_RETRYABLE_PATTERNS = [
+  /timeout/i,
+  /rate.limit/i,
+  /ECONNRESET/i,
+  /ECONNREFUSED/i,
+  /503/i,
+  /429/i,
+  /overloaded/i,
+];
+
+/**
+ * Promisified sleep utility
+ */
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Check if an error is retryable based on its message
+ */
+function isRetryableError(
+  error: unknown,
+  customPatterns?: string[]
+): boolean {
+  const message =
+    error instanceof Error ? error.message : String(error);
+
+  // Check default patterns
+  for (const pattern of DEFAULT_RETRYABLE_PATTERNS) {
+    if (pattern.test(message)) {
+      return true;
+    }
+  }
+
+  // Check custom patterns
+  if (customPatterns) {
+    for (const pattern of customPatterns) {
+      if (message.includes(pattern)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Execute a function with retry logic and exponential backoff
+ *
+ * Only retries on transient errors (API timeouts, rate limits, connection errors).
+ * SDK logic failures (tool errors, permission errors) are not retried.
+ */
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  options?: RetryOptions
+): Promise<RetryResult<T>> {
+  const maxAttempts = options?.maxAttempts ?? 3;
+  const initialDelayMs = options?.initialDelayMs ?? 30_000;
+  const maxDelayMs = options?.maxDelayMs ?? 120_000;
+  const backoffMultiplier = options?.backoffMultiplier ?? 2;
+  const retryableErrors = options?.retryableErrors;
+
+  let attempt = 1;
+  let totalRetryDelayMs = 0;
+
+  while (true) {
+    try {
+      const result = await fn();
+      return { result, attempts: attempt, totalRetryDelayMs };
+    } catch (error) {
+      if (attempt >= maxAttempts || !isRetryableError(error, retryableErrors)) {
+        throw error;
+      }
+
+      const delayMs = Math.min(
+        initialDelayMs * Math.pow(backoffMultiplier, attempt - 1),
+        maxDelayMs
+      );
+
+      const errorMsg =
+        error instanceof Error ? error.message : String(error);
+      process.stderr.write(
+        `[retry] Attempt ${attempt}/${maxAttempts} failed: ${errorMsg}\n` +
+          `[retry] Retrying in ${Math.round(delayMs / 1000)}s...\n`
+      );
+
+      await sleep(delayMs);
+      totalRetryDelayMs += delayMs;
+      attempt++;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements all 5 tiers from #185 — concurrent multi-issue execution, failure resilience, and structured observability for the automation layer.

- **Retry logic** (`retry.ts`): `withRetry()` with exponential backoff (30s → 60s → 120s, max 3 attempts). Only retries transient errors (timeouts, rate limits, connection resets) — SDK logic failures propagate immediately.
- **Checkpointing** (`checkpoint.ts`): Atomic JSON checkpoints after each phase at `automation/.data/checkpoints/`. Enables `--resume <issue>` to pick up from last completed phase.
- **Batch runner** (`batch.ts`): Concurrent execution with zero-dependency semaphore-based concurrency control. `--batch #123 #124 #125` or `--batch-label auto:implement` with configurable `--concurrency`.
- **NDJSON logging** (`logger.ts`): Machine-queryable `events.ndjson` written alongside existing human-readable `workflow.log`. One JSON object per event with timestamp, event type, phase, and level.
- **Run manifest** (`manifest.ts`): Tracks all active/recent runs at `automation/.data/manifest.json` with atomic writes. `--status` pretty-prints an ASCII status table.
- **GitHub Action** (`adw-trigger.yml`): Triggers automation when `auto:implement` or `auto:review` labels are added. Concurrency groups per issue, 60min timeout, success/failure comments with run links.

### New CLI flags
```bash
--batch <issues...>       # Run multiple issues concurrently
--batch-label <label>     # Discover and run labeled issues
--concurrency <n>         # Control parallelism (default: 3)
--resume <issue>          # Resume from latest checkpoint
--status                  # Display run manifest
```

### Files changed
| File | Type | Purpose |
|------|------|---------|
| `automation/src/retry.ts` | New | Exponential backoff retry utility |
| `automation/src/checkpoint.ts` | New | Phase checkpoint read/write/clear |
| `automation/src/batch.ts` | New | Concurrent batch runner with semaphore |
| `automation/src/manifest.ts` | New | Run manifest tracking |
| `.github/workflows/adw-trigger.yml` | New | Label-triggered GitHub Action |
| `automation/src/orchestrator.ts` | Modified | Retry wrapping, checkpoint emission, resume logic |
| `automation/src/logger.ts` | Modified | NDJSON event writer |
| `automation/src/index.ts` | Modified | All new CLI flags |
| `automation/src/workflow.ts` | Modified | Resume pass-through |

Closes #185

## Test plan

- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] All 903 tests pass, 0 failures
- [x] Existing single-issue flow unchanged and backward-compatible
- [ ] Test `--batch #1 #2` with dry-run mode
- [ ] Test `--resume` after intentionally interrupted workflow
- [ ] Test `--status` output formatting
- [ ] Verify `events.ndjson` written alongside `workflow.log`
- [ ] Verify GitHub Action triggers on label addition