### PR TITLE
feat(mcp): improve contextual tips in search results

### DIFF
--- a/app/tests/mcp/search-tips.test.ts
+++ b/app/tests/mcp/search-tips.test.ts
@@ -1,91 +1,582 @@
+/**
+ * Tests for generateSearchTips() via executeSearch
+ *
+ * Following antimocking philosophy: uses real global database (no mocks).
+ * generateSearchTips is not exported, so all testing is done indirectly
+ * through executeSearch which calls formatSearchResults -> generateSearchTips.
+ *
+ * Test Coverage:
+ * - Empty results tips (nonsense query, filtered empty)
+ * - MAX_TIPS = 2 enforcement
+ * - Priority ordering (high before low)
+ * - Context-aware suppression (glob, repository, multi-scope)
+ * - Backward compatibility (tips is string[], optional)
+ * - Structural keyword tips (Pattern 1)
+ * - Error/why/how keyword tips (Patterns 6-8)
+ * - seenTips parameter (not passed via executeSearch, verified structurally)
+ *
+ * @module tests/mcp/search-tips
+ */
+
 import { describe, test, expect } from "bun:test";
+import { executeSearch } from "@mcp/tools";
 
-// Note: generateSearchTips is not exported, so we test it indirectly through executeSearch
-// This test file serves as documentation for the expected tip patterns
+const REQUEST_ID = "test-search-tips";
+const USER_ID = "test-user";
 
-describe("Search Tips Pattern Documentation", () => {
-	test("documents Pattern 1: structural keywords suggest symbols scope", () => {
-		// When query contains "function", "class", "interface", "type", "method", "component"
-		// and scope is "code" (not "symbols")
-		// Tip: 'You searched for "X" in code. Try scope: ['symbols'] with filters: {symbol_kind: ['function']} for precise structural discovery.'
-		expect(true).toBe(true);
+/**
+ * Helper to extract tips from a search result.
+ * Returns the tips array or undefined if absent.
+ */
+function getTips(result: unknown): string[] | undefined {
+	const response = result as Record<string, unknown>;
+	return response.tips as string[] | undefined;
+}
+
+describe("Search Tips - Empty Results", () => {
+	test("should return 'No results found' tip for nonsense query with zero results", async () => {
+		const result = await executeSearch(
+			{
+				query: "xyznonexistent12345qqq",
+				scope: ["code"],
+				limit: 10,
+			},
+			REQUEST_ID,
+			USER_ID,
+		);
+
+		const response = result as Record<string, unknown>;
+		const counts = response.counts as Record<string, unknown>;
+		const tips = getTips(result);
+
+		// Only assert on tips when we truly got zero results
+		if (counts.total === 0) {
+			expect(tips).toBeDefined();
+			expect(tips!.length).toBeGreaterThanOrEqual(1);
+			expect(tips!.some(t => t.includes("No results found"))).toBe(true);
+		}
 	});
 
-	test("documents Pattern 2: file path suggests search_dependencies", () => {
-		// When query looks like a file path (matches: /^[\w\-./]+\.(ts|tsx|js|jsx|py|rs|go|java)$/i)
-		// and scope includes "code"
-		// Tip: 'Query "X" looks like a file path. Consider using search_dependencies tool...'
-		expect(true).toBe(true);
+	test("should return 'active filters' tip when searching with filters and zero results", async () => {
+		const result = await executeSearch(
+			{
+				query: "xyznonexistent12345qqq",
+				scope: ["code"],
+				filters: { glob: "**/*.nonexistent_extension_xyz" },
+				limit: 10,
+			},
+			REQUEST_ID,
+			USER_ID,
+		);
+
+		const response = result as Record<string, unknown>;
+		const counts = response.counts as Record<string, unknown>;
+		const tips = getTips(result);
+
+		if (counts.total === 0) {
+			expect(tips).toBeDefined();
+			expect(tips!.some(t => t.includes("active filters"))).toBe(true);
+		}
 	});
 
-	test("documents Pattern 3: large symbol results suggest exported_only filter", () => {
-		// When scope includes "symbols"
-		// and exported_only filter is undefined
-		// and symbol result count > 10
-		// Tip: 'Found N symbols. Add filters: {exported_only: true} to narrow to public API only.'
-		expect(true).toBe(true);
-	});
+	test("should return at most 2 tips even for empty results with active filters", async () => {
+		const result = await executeSearch(
+			{
+				query: "xyznonexistent12345qqq",
+				scope: ["code"],
+				filters: { glob: "**/*.xyz", language: "nonexistent" },
+				limit: 10,
+			},
+			REQUEST_ID,
+			USER_ID,
+		);
 
-	test("documents Pattern 4: large result set suggests repository filter", () => {
-		// When repositoryId filter is undefined
-		// and total results > 20
-		// Tip: 'Found N results across all repositories. Add filters: {repository: "owner/repo"}...'
-		expect(true).toBe(true);
-	});
-
-	test("documents Pattern 5: code search suggests glob/language filters", () => {
-		// When scope includes "code"
-		// and no glob or language filters
-		// and code result count > 15
-		// Tip: 'Found N code results. Try filters: {glob: "**/*.ts"} or {language: "typescript"}...'
-		expect(true).toBe(true);
-	});
-
-	test("documents Pattern 6: why questions suggest decisions scope", () => {
-		// When query matches /\b(why|reason|decision|chose|choice)\b/i
-		// and scope does not include "decisions"
-		// Tip: 'Query contains "why/reason/decision". Try scope: ['decisions']...'
-		expect(true).toBe(true);
-	});
-
-	test("documents Pattern 7: how questions suggest patterns scope", () => {
-		// When query matches /\b(how|pattern|best practice|convention)\b/i
-		// and scope does not include "patterns"
-		// Tip: 'Query asks "how to". Try scope: ['patterns']...'
-		expect(true).toBe(true);
-	});
-
-	test("documents Pattern 8: error queries suggest failures scope", () => {
-		// When query matches /\b(error|bug|fail|issue|problem|fix)\b/i
-		// and scope does not include "failures"
-		// Tip: 'Query mentions errors/issues. Try scope: ['failures']...'
-		expect(true).toBe(true);
-	});
-
-	test("documents Pattern 9: single code scope suggests multi-scope", () => {
-		// When scope.length === 1 and scope[0] === "code"
-		// Tip: 'Tip: You can search multiple scopes simultaneously...'
-		expect(true).toBe(true);
-	});
-
-	test("documents Pattern 10: large results suggest compact format", () => {
-		// When total results > 30
-		// and no tip already includes 'output: "compact"'
-		// Tip: 'Returning N full results. Use output: "compact" for summary view...'
-		expect(true).toBe(true);
+		const tips = getTips(result);
+		if (tips) {
+			expect(tips.length).toBeLessThanOrEqual(2);
+		}
 	});
 });
 
-describe("Search Tips Integration", () => {
-	test("tips are added to search response when applicable", async () => {
-		// This would require mocking or actual database
-		// Integration tests should verify tips appear in response
-		expect(true).toBe(true);
+describe("Search Tips - MAX_TIPS Limit", () => {
+	test("should never return more than 2 tips", async () => {
+		// Use a query that triggers many patterns:
+		// - "function" -> Pattern 1 (structural keyword, suggests symbols)
+		// - "error" -> Pattern 8 (error keyword, suggests failures)
+		// - single scope "code" -> Pattern 9 (suggests multi-scope)
+		// This should trigger 3+ patterns, but only 2 should be returned
+		const result = await executeSearch(
+			{
+				query: "function error handler",
+				scope: ["code"],
+				limit: 100,
+			},
+			REQUEST_ID,
+			USER_ID,
+		);
+
+		const tips = getTips(result);
+		if (tips) {
+			expect(tips.length).toBeLessThanOrEqual(2);
+		}
 	});
 
-	test("tips are omitted when search is optimal", async () => {
-		// When all parameters are well-chosen
-		// tips array should be empty or omitted
-		expect(true).toBe(true);
+	test("should return at most 2 tips when many patterns match with large results", async () => {
+		// Query with "why" (Pattern 6), "how" (Pattern 7), single "code" scope (Pattern 9)
+		const result = await executeSearch(
+			{
+				query: "why and how to fix pattern",
+				scope: ["code"],
+				limit: 100,
+			},
+			REQUEST_ID,
+			USER_ID,
+		);
+
+		const tips = getTips(result);
+		if (tips) {
+			expect(tips.length).toBeLessThanOrEqual(2);
+		}
+	});
+});
+
+describe("Search Tips - Priority Ordering", () => {
+	test("should prioritize high-priority scope tips over low-priority format tips", async () => {
+		// "function" triggers Pattern 1 (high priority, scope)
+		// Single "code" scope triggers Pattern 9 (low priority, scope)
+		// If results > 30, Pattern 10 fires (low priority, format)
+		// High priority tips should appear before low priority
+		const result = await executeSearch(
+			{
+				query: "function",
+				scope: ["code"],
+				limit: 100,
+			},
+			REQUEST_ID,
+			USER_ID,
+		);
+
+		const tips = getTips(result);
+		if (tips && tips.length > 0) {
+			// The first tip should be a high-priority one (Pattern 1 about symbols)
+			// and NOT the low-priority Pattern 9 about multi-scope
+			const firstTip = tips[0]!;
+			const isHighPriority =
+				firstTip.includes("symbols") || // Pattern 1
+				firstTip.includes("No results found") || // Empty results
+				firstTip.includes("errors/issues") || // Pattern 8
+				firstTip.includes("how to") || // Pattern 7
+				firstTip.includes("why/reason") || // Pattern 6
+				firstTip.includes("file path"); // Pattern 2
+			// If we got tips, at least the first should be high priority
+			// (not the low-priority "You can search multiple scopes" or "compact" tip)
+			expect(isHighPriority).toBe(true);
+		}
+	});
+
+	test("should prefer structural keyword tip (high) over multi-scope tip (low)", async () => {
+		// "class" triggers Pattern 1 (high priority)
+		// scope: ["code"] triggers Pattern 9 (low priority)
+		const result = await executeSearch(
+			{
+				query: "class DataProcessor",
+				scope: ["code"],
+				limit: 20,
+			},
+			REQUEST_ID,
+			USER_ID,
+		);
+
+		const tips = getTips(result);
+		if (tips && tips.length >= 1) {
+			// First tip should mention symbols (Pattern 1, high priority)
+			expect(tips[0]!.includes("symbols") || tips[0]!.includes("No results")).toBe(true);
+		}
+	});
+});
+
+describe("Search Tips - Context-Aware Suppression", () => {
+	test("should NOT suggest file type filters when glob filter is already set", async () => {
+		// Pattern 5 should be suppressed when glob is set
+		const result = await executeSearch(
+			{
+				query: "import",
+				scope: ["code"],
+				filters: { glob: "**/*.ts" },
+				limit: 50,
+			},
+			REQUEST_ID,
+			USER_ID,
+		);
+
+		const tips = getTips(result);
+		if (tips) {
+			// No tip should suggest glob filter when glob is already active
+			const suggestsGlob = tips.some(t =>
+				t.includes('glob: "**/*.ts"') && t.includes("narrow file types"),
+			);
+			expect(suggestsGlob).toBe(false);
+		}
+	});
+
+	test("should NOT suggest repository filter when repository is already set", async () => {
+		// Pattern 4 should be suppressed when repository filter is set
+		const result = await executeSearch(
+			{
+				query: "test",
+				scope: ["code"],
+				filters: { repository: "test-owner/test-repo" },
+				limit: 50,
+			},
+			REQUEST_ID,
+			USER_ID,
+		);
+
+		const tips = getTips(result);
+		if (tips) {
+			// No tip should suggest repository filter
+			const suggestsRepo = tips.some(t =>
+				t.includes("repository") && t.includes("narrow to a specific repository"),
+			);
+			expect(suggestsRepo).toBe(false);
+		}
+	});
+
+	test("should NOT suggest multi-scope when multiple scopes are already used", async () => {
+		// Pattern 9 fires only when scopes.length === 1 and scope[0] === "code"
+		const result = await executeSearch(
+			{
+				query: "test data",
+				scope: ["code", "symbols"],
+				limit: 20,
+			},
+			REQUEST_ID,
+			USER_ID,
+		);
+
+		const tips = getTips(result);
+		if (tips) {
+			const suggestsMultiScope = tips.some(t =>
+				t.includes("search multiple scopes simultaneously"),
+			);
+			expect(suggestsMultiScope).toBe(false);
+		}
+	});
+
+	test("should NOT suggest language filter when language is already set", async () => {
+		// Pattern 5 should be suppressed when language is set
+		const result = await executeSearch(
+			{
+				query: "import",
+				scope: ["code"],
+				filters: { language: "typescript" },
+				limit: 50,
+			},
+			REQUEST_ID,
+			USER_ID,
+		);
+
+		const tips = getTips(result);
+		if (tips) {
+			const suggestsLanguage = tips.some(t =>
+				t.includes("narrow file types"),
+			);
+			expect(suggestsLanguage).toBe(false);
+		}
+	});
+});
+
+describe("Search Tips - Backward Compatibility", () => {
+	test("tips field should be an array of strings when present", async () => {
+		const result = await executeSearch(
+			{
+				query: "function handler",
+				scope: ["code"],
+				limit: 10,
+			},
+			REQUEST_ID,
+			USER_ID,
+		);
+
+		const tips = getTips(result);
+		if (tips !== undefined) {
+			expect(Array.isArray(tips)).toBe(true);
+			for (const tip of tips) {
+				expect(typeof tip).toBe("string");
+			}
+		}
+	});
+
+	test("tips field should be undefined when no tips apply", async () => {
+		// Use a well-optimized search that shouldn't trigger tips:
+		// - symbols scope (not code-only, so no Pattern 9)
+		// - exported_only set (no Pattern 3)
+		// - specific query (no structural keywords in code scope)
+		const result = await executeSearch(
+			{
+				query: "User",
+				scope: ["symbols"],
+				filters: {
+					exported_only: true,
+					symbol_kind: ["class"],
+				},
+				limit: 5,
+			},
+			REQUEST_ID,
+			USER_ID,
+		);
+
+		const response = result as Record<string, unknown>;
+		// Tips should either be undefined or an empty case (omitted from response)
+		if (response.tips !== undefined) {
+			expect(Array.isArray(response.tips)).toBe(true);
+		}
+		// The key test: if tips is present, it should be string[]
+		// If absent, that's valid backward compatibility
+	});
+
+	test("response always has query, scopes, results, counts fields", async () => {
+		const result = await executeSearch(
+			{
+				query: "anything",
+				scope: ["code"],
+				limit: 5,
+			},
+			REQUEST_ID,
+			USER_ID,
+		);
+
+		const response = result as Record<string, unknown>;
+		expect(response.query).toBe("anything");
+		expect(Array.isArray(response.scopes)).toBe(true);
+		expect(response.results).toBeDefined();
+		expect(response.counts).toBeDefined();
+	});
+});
+
+describe("Search Tips - Structural Keyword Tips (Pattern 1)", () => {
+	test("should suggest symbols scope when query contains 'function' in code scope", async () => {
+		const result = await executeSearch(
+			{
+				query: "function parseConfig",
+				scope: ["code"],
+				limit: 10,
+			},
+			REQUEST_ID,
+			USER_ID,
+		);
+
+		const tips = getTips(result);
+		if (tips) {
+			const hasScopeSymbolsTip = tips.some(t =>
+				t.includes("symbols") && t.includes("function"),
+			);
+			// Pattern 1 should fire since query has "function" and scope is code (not symbols)
+			expect(hasScopeSymbolsTip).toBe(true);
+		}
+	});
+
+	test("should suggest symbols scope when query contains 'class'", async () => {
+		const result = await executeSearch(
+			{
+				query: "class UserService",
+				scope: ["code"],
+				limit: 10,
+			},
+			REQUEST_ID,
+			USER_ID,
+		);
+
+		const tips = getTips(result);
+		if (tips) {
+			const hasClassTip = tips.some(t =>
+				t.includes("symbols") && t.includes("class"),
+			);
+			expect(hasClassTip).toBe(true);
+		}
+	});
+
+	test("should NOT suggest symbols scope when already using symbols scope", async () => {
+		const result = await executeSearch(
+			{
+				query: "function parseConfig",
+				scope: ["symbols"],
+				limit: 10,
+			},
+			REQUEST_ID,
+			USER_ID,
+		);
+
+		const tips = getTips(result);
+		if (tips) {
+			const hasScopeSymbolsTip = tips.some(t =>
+				t.includes("Try scope: ['symbols']"),
+			);
+			expect(hasScopeSymbolsTip).toBe(false);
+		}
+	});
+
+	test("should suggest symbols scope when query contains 'interface'", async () => {
+		const result = await executeSearch(
+			{
+				query: "interface Config",
+				scope: ["code"],
+				limit: 10,
+			},
+			REQUEST_ID,
+			USER_ID,
+		);
+
+		const tips = getTips(result);
+		if (tips) {
+			const hasInterfaceTip = tips.some(t =>
+				t.includes("symbols") && t.includes("interface"),
+			);
+			expect(hasInterfaceTip).toBe(true);
+		}
+	});
+});
+
+describe("Search Tips - Decision/Pattern/Failure Scope Tips", () => {
+	test("should suggest decisions scope for 'why' questions (Pattern 6)", async () => {
+		const result = await executeSearch(
+			{
+				query: "why use SQLite",
+				scope: ["code"],
+				limit: 10,
+			},
+			REQUEST_ID,
+			USER_ID,
+		);
+
+		const tips = getTips(result);
+		if (tips) {
+			const hasDecisionTip = tips.some(t =>
+				t.includes("decisions") && t.includes("why/reason/decision"),
+			);
+			expect(hasDecisionTip).toBe(true);
+		}
+	});
+
+	test("should suggest patterns scope for 'how' questions (Pattern 7)", async () => {
+		const result = await executeSearch(
+			{
+				query: "how to handle errors",
+				scope: ["code"],
+				limit: 10,
+			},
+			REQUEST_ID,
+			USER_ID,
+		);
+
+		const tips = getTips(result);
+		if (tips) {
+			const hasPatternTip = tips.some(t =>
+				t.includes("patterns") && t.includes("how to"),
+			);
+			expect(hasPatternTip).toBe(true);
+		}
+	});
+
+	test("should suggest failures scope for error-related queries (Pattern 8)", async () => {
+		const result = await executeSearch(
+			{
+				query: "fix database error",
+				scope: ["code"],
+				limit: 10,
+			},
+			REQUEST_ID,
+			USER_ID,
+		);
+
+		const tips = getTips(result);
+		if (tips) {
+			const hasFailureTip = tips.some(t =>
+				t.includes("failures") && t.includes("errors/issues"),
+			);
+			expect(hasFailureTip).toBe(true);
+		}
+	});
+
+	test("should NOT suggest decisions scope when already included", async () => {
+		const result = await executeSearch(
+			{
+				query: "why use this pattern",
+				scope: ["code", "decisions"],
+				limit: 10,
+			},
+			REQUEST_ID,
+			USER_ID,
+		);
+
+		const tips = getTips(result);
+		if (tips) {
+			const suggestsDecisions = tips.some(t =>
+				t.includes("Try scope: ['decisions']"),
+			);
+			expect(suggestsDecisions).toBe(false);
+		}
+	});
+
+	test("should NOT suggest patterns scope when already included", async () => {
+		const result = await executeSearch(
+			{
+				query: "how to create a service",
+				scope: ["code", "patterns"],
+				limit: 10,
+			},
+			REQUEST_ID,
+			USER_ID,
+		);
+
+		const tips = getTips(result);
+		if (tips) {
+			const suggestsPatterns = tips.some(t =>
+				t.includes("Try scope: ['patterns']"),
+			);
+			expect(suggestsPatterns).toBe(false);
+		}
+	});
+
+	test("should NOT suggest failures scope when already included", async () => {
+		const result = await executeSearch(
+			{
+				query: "error handling bug",
+				scope: ["code", "failures"],
+				limit: 10,
+			},
+			REQUEST_ID,
+			USER_ID,
+		);
+
+		const tips = getTips(result);
+		if (tips) {
+			const suggestsFailures = tips.some(t =>
+				t.includes("Try scope: ['failures']"),
+			);
+			expect(suggestsFailures).toBe(false);
+		}
+	});
+});
+
+describe("Search Tips - File Path Pattern (Pattern 2)", () => {
+	test("should suggest search_dependencies for file path queries", async () => {
+		const result = await executeSearch(
+			{
+				query: "src/index.ts",
+				scope: ["code"],
+				limit: 10,
+			},
+			REQUEST_ID,
+			USER_ID,
+		);
+
+		const tips = getTips(result);
+		if (tips) {
+			const hasFilePathTip = tips.some(t =>
+				t.includes("search_dependencies") && t.includes("file path"),
+			);
+			expect(hasFilePathTip).toBe(true);
+		}
 	});
 });

--- a/app/tests/mcp/search-with-tips.integration.test.ts
+++ b/app/tests/mcp/search-with-tips.integration.test.ts
@@ -1,5 +1,26 @@
+/**
+ * Integration tests for search tips within executeSearch
+ *
+ * Following antimocking philosophy: uses real global database.
+ * Tests verify that tips integrate correctly with full search pipeline
+ * including scope routing, filter normalization, and result formatting.
+ *
+ * Test Coverage:
+ * - Search response structure with tips
+ * - Tips appear for structural queries
+ * - Tips suppressed for optimized queries
+ * - Multi-scope searches
+ * - Index statistics integration
+ * - End-to-end tip generation with real data
+ *
+ * @module tests/mcp/search-with-tips.integration
+ */
+
 import { describe, test, expect } from "bun:test";
 import { executeSearch } from "@mcp/tools";
+
+const REQUEST_ID = "test-integration";
+const USER_ID = "test-user";
 
 describe("executeSearch with tips integration", () => {
 	test("search response includes required fields", async () => {
@@ -9,20 +30,20 @@ describe("executeSearch with tips integration", () => {
 				scope: ["code"],
 				limit: 10,
 			},
-			"test-request",
-			"test-user"
+			REQUEST_ID,
+			USER_ID,
 		);
-		
+
 		expect(result).toHaveProperty("query");
 		expect(result).toHaveProperty("scopes");
 		expect(result).toHaveProperty("results");
 		expect(result).toHaveProperty("counts");
-		
+
 		const response = result as Record<string, unknown>;
 		expect(response.query).toBe("authentication");
 		expect(Array.isArray(response.scopes)).toBe(true);
 	});
-	
+
 	test("tips field is optional in response", async () => {
 		const result = await executeSearch(
 			{
@@ -30,10 +51,10 @@ describe("executeSearch with tips integration", () => {
 				scope: ["code"],
 				limit: 5,
 			},
-			"test-request",
-			"test-user"
+			REQUEST_ID,
+			USER_ID,
 		);
-		
+
 		// tips may or may not be present depending on search characteristics
 		// If present, it should be an array
 		const response = result as Record<string, unknown>;
@@ -41,49 +62,53 @@ describe("executeSearch with tips integration", () => {
 			expect(Array.isArray(response.tips)).toBe(true);
 		}
 	});
-	
-	test("search with structural query may include tips", async () => {
+
+	test("search with structural query includes tip suggesting symbols scope", async () => {
 		const result = await executeSearch(
 			{
 				query: "function parseUser",
 				scope: ["code"],
 				limit: 20,
 			},
-			"test-request",
-			"test-user"
+			REQUEST_ID,
+			USER_ID,
 		);
-		
+
 		const response = result as Record<string, unknown>;
-		// May have tips suggesting symbols scope
-		// This is pattern-dependent, so we just verify structure
+		// Pattern 1: structural keyword "function" in code scope should suggest symbols
 		if (response.tips) {
 			expect(Array.isArray(response.tips)).toBe(true);
-			expect((response.tips as string[]).length).toBeGreaterThan(0);
+			const tips = response.tips as string[];
+			expect(tips.length).toBeGreaterThan(0);
+			expect(tips.length).toBeLessThanOrEqual(2);
+			// At least one tip should mention symbols scope
+			const mentionsSymbols = tips.some(t => t.includes("symbols"));
+			expect(mentionsSymbols).toBe(true);
 		}
 	});
-	
+
 	test("search with optimal parameters may omit tips", async () => {
 		const result = await executeSearch(
 			{
 				query: "User",
 				scope: ["symbols"],
-				filters: { 
+				filters: {
 					exported_only: true,
-					symbol_kind: ["class"]
+					symbol_kind: ["class"],
 				},
 				limit: 10,
 			},
-			"test-request",
-			"test-user"
+			REQUEST_ID,
+			USER_ID,
 		);
-		
+
 		const response = result as Record<string, unknown>;
 		// Well-formed query should have fewer or no tips
 		if (response.tips) {
 			expect(Array.isArray(response.tips)).toBe(true);
 		}
 	});
-	
+
 	test("search handles all scopes correctly", async () => {
 		const result = await executeSearch(
 			{
@@ -91,12 +116,18 @@ describe("executeSearch with tips integration", () => {
 				scope: ["code", "symbols", "decisions", "patterns", "failures"],
 				limit: 5,
 			},
-			"test-request",
-			"test-user"
+			REQUEST_ID,
+			USER_ID,
 		);
-		
+
 		const response = result as Record<string, unknown>;
-		expect(response.scopes).toEqual(["code", "symbols", "decisions", "patterns", "failures"]);
+		expect(response.scopes).toEqual([
+			"code",
+			"symbols",
+			"decisions",
+			"patterns",
+			"failures",
+		]);
 		expect(response.results).toHaveProperty("code");
 		expect(response.results).toHaveProperty("symbols");
 		expect(response.results).toHaveProperty("decisions");
@@ -105,17 +136,233 @@ describe("executeSearch with tips integration", () => {
 	});
 });
 
+describe("Search Tips - Empty Results Integration", () => {
+	test("nonsense query returns 'No results found' tip with zero total results", async () => {
+		const result = await executeSearch(
+			{
+				query: "xyznonexistent12345qqq",
+				scope: ["code"],
+				limit: 10,
+			},
+			REQUEST_ID,
+			USER_ID,
+		);
+
+		const response = result as Record<string, unknown>;
+		const counts = response.counts as Record<string, unknown>;
+
+		if (counts.total === 0) {
+			expect(response.tips).toBeDefined();
+			const tips = response.tips as string[];
+			expect(tips.some(t => t.includes("No results found"))).toBe(true);
+		}
+	});
+
+	test("nonsense query with filters returns both empty and filter tips", async () => {
+		const result = await executeSearch(
+			{
+				query: "xyznonexistent12345qqq",
+				scope: ["code"],
+				filters: { glob: "**/*.nonexistent_xyz" },
+				limit: 10,
+			},
+			REQUEST_ID,
+			USER_ID,
+		);
+
+		const response = result as Record<string, unknown>;
+		const counts = response.counts as Record<string, unknown>;
+
+		if (counts.total === 0) {
+			expect(response.tips).toBeDefined();
+			const tips = response.tips as string[];
+			// Should have both: "No results found" and "active filters"
+			expect(tips.length).toBe(2);
+			expect(tips.some(t => t.includes("No results found"))).toBe(true);
+			expect(tips.some(t => t.includes("active filters"))).toBe(true);
+		}
+	});
+});
+
+describe("Search Tips - MAX_TIPS Enforcement Integration", () => {
+	test("tips array never exceeds 2 entries regardless of matching patterns", async () => {
+		// "function error" triggers: Pattern 1 (structural), Pattern 8 (error), Pattern 9 (single scope)
+		const result = await executeSearch(
+			{
+				query: "function error handler",
+				scope: ["code"],
+				limit: 100,
+			},
+			REQUEST_ID,
+			USER_ID,
+		);
+
+		const response = result as Record<string, unknown>;
+		if (response.tips) {
+			const tips = response.tips as string[];
+			expect(tips.length).toBeLessThanOrEqual(2);
+		}
+	});
+});
+
+describe("Search Tips - Context Suppression Integration", () => {
+	test("glob filter suppresses file type narrowing tip", async () => {
+		const result = await executeSearch(
+			{
+				query: "import",
+				scope: ["code"],
+				filters: { glob: "**/*.ts" },
+				limit: 100,
+			},
+			REQUEST_ID,
+			USER_ID,
+		);
+
+		const response = result as Record<string, unknown>;
+		if (response.tips) {
+			const tips = response.tips as string[];
+			const suggestsGlobFilter = tips.some(
+				t => t.includes("narrow file types"),
+			);
+			expect(suggestsGlobFilter).toBe(false);
+		}
+	});
+
+	test("multi-scope suppresses single-scope tip", async () => {
+		const result = await executeSearch(
+			{
+				query: "data processing",
+				scope: ["code", "symbols"],
+				limit: 20,
+			},
+			REQUEST_ID,
+			USER_ID,
+		);
+
+		const response = result as Record<string, unknown>;
+		if (response.tips) {
+			const tips = response.tips as string[];
+			const suggestsMultiScope = tips.some(t =>
+				t.includes("search multiple scopes simultaneously"),
+			);
+			expect(suggestsMultiScope).toBe(false);
+		}
+	});
+
+	test("decisions scope in query suppresses decisions tip", async () => {
+		const result = await executeSearch(
+			{
+				query: "why use SQLite database",
+				scope: ["code", "decisions"],
+				limit: 10,
+			},
+			REQUEST_ID,
+			USER_ID,
+		);
+
+		const response = result as Record<string, unknown>;
+		if (response.tips) {
+			const tips = response.tips as string[];
+			const suggestsDecisions = tips.some(t =>
+				t.includes("Try scope: ['decisions']"),
+			);
+			expect(suggestsDecisions).toBe(false);
+		}
+	});
+});
+
+describe("Search Tips - Priority Integration", () => {
+	test("high-priority tips appear first when multiple patterns match", async () => {
+		// "function" (Pattern 1: high) + single code scope (Pattern 9: low)
+		const result = await executeSearch(
+			{
+				query: "function",
+				scope: ["code"],
+				limit: 50,
+			},
+			REQUEST_ID,
+			USER_ID,
+		);
+
+		const response = result as Record<string, unknown>;
+		if (response.tips) {
+			const tips = response.tips as string[];
+			if (tips.length >= 2) {
+				// First tip should be a high-priority one (symbols suggestion)
+				// NOT the low-priority multi-scope tip
+				expect(
+					tips[0]!.includes("search multiple scopes simultaneously"),
+				).toBe(false);
+			}
+		}
+	});
+});
+
+describe("Search Tips - Backward Compatibility Integration", () => {
+	test("each tip in the array is a plain string", async () => {
+		const result = await executeSearch(
+			{
+				query: "function error why",
+				scope: ["code"],
+				limit: 20,
+			},
+			REQUEST_ID,
+			USER_ID,
+		);
+
+		const response = result as Record<string, unknown>;
+		if (response.tips) {
+			const tips = response.tips as unknown[];
+			for (const tip of tips) {
+				expect(typeof tip).toBe("string");
+				// Tips should not be objects (SearchTip interface is internal)
+				expect(typeof tip).not.toBe("object");
+			}
+		}
+	});
+
+	test("tips are excluded from response when no patterns match", async () => {
+		// Optimize query to avoid triggering any tips:
+		// - Use "symbols" scope (no Pattern 9)
+		// - Set exported_only (no Pattern 3)
+		// - Use non-keyword query (no Patterns 1,6,7,8)
+		// - Set repository filter (no Pattern 4)
+		const result = await executeSearch(
+			{
+				query: "User",
+				scope: ["symbols"],
+				filters: {
+					exported_only: true,
+					repository: "test-owner/test-repo",
+				},
+				limit: 5,
+			},
+			REQUEST_ID,
+			USER_ID,
+		);
+
+		const response = result as Record<string, unknown>;
+		const counts = response.counts as Record<string, unknown>;
+
+		// If zero results, tips will be present (empty result tip)
+		// If results exist with well-optimized query, tips should be absent
+		if ((counts.total as number) > 0) {
+			// No tips should have been generated
+			expect(response.tips).toBeUndefined();
+		}
+	});
+});
+
 describe("executeGetIndexStatistics integration", () => {
 	test("get_index_statistics returns expected structure", async () => {
-		// Import the executor
 		const { executeGetIndexStatistics } = await import("@mcp/tools");
-		
+
 		const result = await executeGetIndexStatistics(
 			{},
-			"test-request",
-			"test-user"
+			REQUEST_ID,
+			USER_ID,
 		);
-		
+
 		expect(result).toHaveProperty("files");
 		expect(result).toHaveProperty("symbols");
 		expect(result).toHaveProperty("references");
@@ -124,7 +371,7 @@ describe("executeGetIndexStatistics integration", () => {
 		expect(result).toHaveProperty("failures");
 		expect(result).toHaveProperty("repositories");
 		expect(result).toHaveProperty("summary");
-		
+
 		const stats = result as Record<string, unknown>;
 		expect(typeof stats.summary).toBe("string");
 	});


### PR DESCRIPTION
## Summary

Closes #171

Refactors `generateSearchTips()` in `app/src/mcp/tools.ts` with five improvements to make search tips more relevant and less noisy:

- **Priority ranking**: All 10 tip patterns now have assigned priorities (high/medium/low). Tips are sorted by impact before being returned.
- **Max 2 tips per response**: Caps output to the 2 most relevant tips instead of showing all matching patterns.
- **Empty results guidance**: When a search returns 0 results, provides actionable tips ("Try broader terms", "Remove filters").
- **Context-aware suppression**: Tips no longer contradict intentional user filters (e.g., won't suggest "add glob filter" when one is already set).
- **Tip deduplication**: New optional `seenTips` parameter allows callers to suppress previously shown tips across a session.

Internal `SearchTip` interface with `{category, message, priority}` is used for ranking; the public return type remains `string[]` for full backward compatibility.

## Test plan

- [x] 40 tests pass (72 assertions) across both test files
- [x] `bunx tsc --noEmit` — zero errors
- [x] Pre-commit hooks pass (type-check + lint)
- [x] Existing test suite unaffected (903 pass before, still passes)