### PR TITLE
refactor(automation): load .claude/agents/ prompts instead of inline stubs, add validate phase (#195)

### DIFF
--- a/automation/src/prompt-loader.ts
+++ b/automation/src/prompt-loader.ts
@@ -1,0 +1,244 @@
+/**
+ * Prompt loading utilities for ADW orchestrator
+ *
+ * Loads agent prompt files and expertise YAML for dynamic prompt construction.
+ * Used by the orchestrator to build phase-specific prompts with proper
+ * frontmatter stripping, conventions extraction, and variable injection.
+ */
+import { join } from "node:path";
+
+/**
+ * Load an agent prompt file, strip YAML frontmatter, and return the markdown body.
+ *
+ * Reads `.claude/agents/experts/{domain}/{domain}-{phase}-agent.md`, removes
+ * the YAML frontmatter block (delimited by `---`), and returns the trimmed
+ * markdown content.
+ *
+ * @param domain - Expert domain name (e.g., "automation", "database")
+ * @param phase - Workflow phase (e.g., "plan", "build", "improve")
+ * @param basePath - Project root directory. Defaults to process.cwd()
+ * @returns The markdown body of the agent prompt with frontmatter stripped
+ * @throws Error if the agent prompt file is not found
+ */
+export async function loadAgentPrompt(
+  domain: string,
+  phase: string,
+  basePath?: string
+): Promise<string> {
+  const root = basePath ?? process.cwd();
+  const filename = `${domain}-${phase}-agent.md`;
+  const filePath = join(root, ".claude", "agents", "experts", domain, filename);
+
+  const file = Bun.file(filePath);
+  const exists = await file.exists();
+  if (!exists) {
+    throw new Error(
+      `Agent prompt not found: ${filePath} (domain="${domain}", phase="${phase}")`
+    );
+  }
+
+  const raw = await file.text();
+  return stripFrontmatter(raw);
+}
+
+/**
+ * Strip YAML frontmatter from a markdown string.
+ *
+ * Frontmatter is defined as content between the first `---` (at the start of
+ * the file) and the next `---` line. If no frontmatter is detected, the
+ * original content is returned as-is.
+ */
+function stripFrontmatter(content: string): string {
+  const trimmed = content.trimStart();
+  if (!trimmed.startsWith("---")) {
+    return content.trim();
+  }
+
+  // Find the closing `---` after the opening one
+  const endIndex = trimmed.indexOf("\n---", 3);
+  if (endIndex === -1) {
+    // No closing delimiter found; return content as-is
+    return content.trim();
+  }
+
+  // Skip past the closing `---` and its newline
+  const afterFrontmatter = trimmed.slice(endIndex + 4);
+  return afterFrontmatter.trim();
+}
+
+/**
+ * Load expertise YAML for a domain and extract a compact conventions summary.
+ *
+ * Reads `.claude/agents/experts/{domain}/expertise.yaml` and produces a
+ * ~500-1000 token markdown summary covering path aliases, logging rules,
+ * key utility signatures, and naming conventions.
+ *
+ * @param domain - Expert domain name (e.g., "automation", "database")
+ * @param basePath - Project root directory. Defaults to process.cwd()
+ * @returns Formatted markdown string under a "## Codebase Conventions" header
+ * @throws Error if the expertise file is not found
+ */
+export async function loadExpertiseConventions(
+  domain: string,
+  basePath?: string
+): Promise<string> {
+  const root = basePath ?? process.cwd();
+  const filePath = join(root, ".claude", "agents", "experts", domain, "expertise.yaml");
+
+  const file = Bun.file(filePath);
+  const exists = await file.exists();
+  if (!exists) {
+    throw new Error(
+      `Expertise file not found: ${filePath} (domain="${domain}")`
+    );
+  }
+
+  const raw = await file.text();
+  return extractConventionsSummary(raw, domain);
+}
+
+/**
+ * Extract a compact conventions summary from raw expertise YAML.
+ *
+ * Parses the YAML text line-by-line to extract key sections:
+ * - Scope / primary codebase files
+ * - Best practices
+ * - Key operations (names only)
+ * - Known patterns
+ *
+ * This avoids pulling in a full YAML parser dependency.
+ */
+function extractConventionsSummary(yamlContent: string, domain: string): string {
+  const lines = yamlContent.split("\n");
+  const sections: {
+    scope: string[];
+    bestPractices: string[];
+    keyOps: string[];
+    patterns: string[];
+  } = {
+    scope: [],
+    bestPractices: [],
+    keyOps: [],
+    patterns: []
+  };
+
+  let currentTopLevel = "";
+  let currentSecondLevel = "";
+
+  for (const line of lines) {
+    // Track top-level keys (no indentation)
+    if (/^[a-z_]+:/.test(line)) {
+      currentTopLevel = line.split(":")[0]!.trim();
+      currentSecondLevel = "";
+      continue;
+    }
+
+    // Track second-level keys (2-space indent)
+    if (/^  [a-z_]+:/.test(line)) {
+      currentSecondLevel = line.trim().split(":")[0]!.trim();
+
+      // Capture key operation names
+      if (currentTopLevel === "key_operations") {
+        sections.keyOps.push(currentSecondLevel);
+      }
+      // Capture pattern names
+      if (currentTopLevel === "patterns") {
+        sections.patterns.push(currentSecondLevel.replace(/_/g, " "));
+      }
+      continue;
+    }
+
+    // Capture scope file paths
+    if (currentTopLevel === "overview" && currentSecondLevel === "primary_codebase") {
+      const match = line.match(/^\s+-\s+(.+)$/);
+      if (match?.[1]) {
+        sections.scope.push(match[1].trim());
+      }
+    }
+
+    // Capture best practice bullet points (top-level items under best_practices subsections)
+    if (currentTopLevel === "best_practices") {
+      const match = line.match(/^\s{4}-\s+(.+)$/);
+      if (match?.[1]) {
+        sections.bestPractices.push(match[1].trim());
+      }
+    }
+  }
+
+  // Build compact markdown summary
+  const parts: string[] = [];
+  parts.push(`## Codebase Conventions (${domain})`);
+  parts.push("");
+
+  if (sections.scope.length > 0) {
+    parts.push("### Key Files");
+    for (const f of sections.scope.slice(0, 10)) {
+      parts.push(`- \`${f}\``);
+    }
+    parts.push("");
+  }
+
+  if (sections.bestPractices.length > 0) {
+    parts.push("### Best Practices");
+    for (const bp of sections.bestPractices.slice(0, 15)) {
+      parts.push(`- ${bp}`);
+    }
+    parts.push("");
+  }
+
+  if (sections.keyOps.length > 0) {
+    parts.push("### Key Operations");
+    for (const op of sections.keyOps) {
+      parts.push(`- \`${op}\``);
+    }
+    parts.push("");
+  }
+
+  if (sections.patterns.length > 0) {
+    parts.push("### Patterns");
+    for (const p of sections.patterns) {
+      parts.push(`- ${p}`);
+    }
+    parts.push("");
+  }
+
+  return parts.join("\n").trim();
+}
+
+/**
+ * Build a complete phase prompt by combining an agent body with variable injections.
+ *
+ * Takes the loaded agent prompt body (from {@link loadAgentPrompt}) and a
+ * variables dictionary, then appends a `## Variables (Provided by Automation)`
+ * section listing each defined variable. Undefined variables are skipped.
+ *
+ * @param agentBody - The markdown body of the agent prompt
+ * @param variables - Key-value pairs to inject. Undefined values are omitted.
+ * @returns The combined prompt string ready for SDK query()
+ */
+export function buildPhasePrompt(
+  agentBody: string,
+  variables: Record<string, string | undefined>
+): string {
+  const definedEntries = Object.entries(variables).filter(
+    (entry): entry is [string, string] => entry[1] !== undefined
+  );
+
+  if (definedEntries.length === 0) {
+    return agentBody;
+  }
+
+  const variableLines = definedEntries.map(
+    ([key, value]) => `- **${key}**: ${value}`
+  );
+
+  const variablesSection = [
+    "",
+    "## Variables (Provided by Automation)",
+    "",
+    ...variableLines,
+    ""
+  ].join("\n");
+
+  return agentBody + variablesSection;
+}

--- a/automation/src/validator.ts
+++ b/automation/src/validator.ts
@@ -1,0 +1,345 @@
+/**
+ * Build output validator for ADW orchestrator
+ * Runs type-check, tests, and convention scans on modified files
+ */
+
+/** Result of a full validation pass */
+export interface ValidationResult {
+  passed: boolean;
+  typeCheck: { passed: boolean; errors: string[] };
+  tests: { passed: boolean; errors: string[]; skipped: boolean };
+  conventions: { passed: boolean; violations: string[] };
+  /** Human-readable summary */
+  summary: string;
+}
+
+/** Options for validateBuildOutput */
+export interface ValidateOptions {
+  /** Path to run tsc/tests in */
+  projectRoot: string;
+  /** List of modified file paths */
+  filesModified: string[];
+  /** Skip test execution */
+  skipTests?: boolean;
+  /** Skip tsc --noEmit */
+  skipTypeCheck?: boolean;
+}
+
+/** Timeout for type-check (60 seconds) */
+const TYPE_CHECK_TIMEOUT_MS = 60_000;
+
+/** Timeout for test execution (120 seconds) */
+const TEST_TIMEOUT_MS = 120_000;
+
+/** Maximum depth for relative imports before suggesting path aliases */
+const MAX_RELATIVE_DEPTH = 3;
+
+/** Patterns that violate the no-console convention */
+const CONSOLE_PATTERNS = [
+  /\bconsole\.log\b/,
+  /\bconsole\.warn\b/,
+  /\bconsole\.error\b/,
+  /\bconsole\.info\b/,
+];
+
+/**
+ * Run a subprocess with a timeout, returning stdout, stderr, and exit code
+ */
+async function runCommand(
+  args: string[],
+  cwd: string,
+  timeoutMs: number,
+): Promise<{ stdout: string; stderr: string; exitCode: number; timedOut: boolean }> {
+  const proc = Bun.spawn(args, {
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    proc.kill();
+  }, timeoutMs);
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  clearTimeout(timer);
+  return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode, timedOut };
+}
+
+/**
+ * Run type-check via bunx tsc --noEmit
+ */
+async function runTypeCheck(
+  projectRoot: string,
+): Promise<{ passed: boolean; errors: string[] }> {
+  const { stdout, stderr, exitCode, timedOut } = await runCommand(
+    ["bunx", "tsc", "--noEmit"],
+    projectRoot,
+    TYPE_CHECK_TIMEOUT_MS,
+  );
+
+  if (timedOut) {
+    return { passed: false, errors: ["Type-check timed out after 60s"] };
+  }
+
+  if (exitCode === 0) {
+    return { passed: true, errors: [] };
+  }
+
+  // Parse tsc error output - errors appear on stdout for tsc
+  const output = stdout || stderr;
+  const errorLines = output
+    .split("\n")
+    .filter((line) => line.includes("error TS"))
+    .map((line) => line.trim());
+
+  // If we couldn't parse specific errors, include the raw output (truncated)
+  if (errorLines.length === 0 && output.length > 0) {
+    const truncated =
+      output.length > 1000 ? output.substring(0, 1000) + "..." : output;
+    return { passed: false, errors: [truncated] };
+  }
+
+  return { passed: false, errors: errorLines };
+}
+
+/**
+ * Run tests via bun test
+ */
+async function runTests(
+  projectRoot: string,
+): Promise<{ passed: boolean; errors: string[]; skipped: boolean }> {
+  // Check if any test files exist
+  const findProc = Bun.spawn(
+    ["find", projectRoot, "-name", "*.test.ts", "-o", "-name", "*.spec.ts"],
+    { cwd: projectRoot, stdout: "pipe", stderr: "pipe" },
+  );
+  const findOutput = await new Response(findProc.stdout).text();
+  await findProc.exited;
+
+  if (findOutput.trim().length === 0) {
+    return { passed: true, errors: [], skipped: true };
+  }
+
+  const { stdout, stderr, exitCode, timedOut } = await runCommand(
+    ["bun", "test"],
+    projectRoot,
+    TEST_TIMEOUT_MS,
+  );
+
+  if (timedOut) {
+    return { passed: false, errors: ["Tests timed out after 120s"], skipped: false };
+  }
+
+  if (exitCode === 0) {
+    return { passed: true, errors: [], skipped: false };
+  }
+
+  // Parse test failure output
+  const output = stdout || stderr;
+  const failureLines = output
+    .split("\n")
+    .filter(
+      (line) =>
+        line.includes("FAIL") ||
+        line.includes("error:") ||
+        line.includes("Error:") ||
+        line.includes("expected"),
+    )
+    .map((line) => line.trim())
+    .slice(0, 20); // Cap at 20 lines
+
+  if (failureLines.length === 0 && output.length > 0) {
+    const truncated =
+      output.length > 1000 ? output.substring(0, 1000) + "..." : output;
+    return { passed: false, errors: [truncated], skipped: false };
+  }
+
+  return { passed: false, errors: failureLines, skipped: false };
+}
+
+/**
+ * Scan modified files for convention violations
+ */
+async function scanConventions(
+  filesModified: string[],
+): Promise<{ passed: boolean; violations: string[] }> {
+  const violations: string[] = [];
+
+  for (const filePath of filesModified) {
+    if (!filePath.endsWith(".ts")) continue;
+
+    let content: string;
+    try {
+      const file = Bun.file(filePath);
+      content = await file.text();
+    } catch {
+      // File might not exist (deleted), skip it
+      continue;
+    }
+
+    const lines = content.split("\n");
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]!;
+      const lineNum = i + 1;
+
+      // Check for console.* usage
+      for (const pattern of CONSOLE_PATTERNS) {
+        if (pattern.test(line)) {
+          // Skip if it's in a comment
+          const trimmed = line.trim();
+          if (trimmed.startsWith("//") || trimmed.startsWith("*")) continue;
+          violations.push(
+            `${filePath}:${lineNum}: console.* usage (use process.stdout/stderr.write)`,
+          );
+        }
+      }
+
+      // Check for deep relative imports in app/src/ files
+      if (filePath.includes("app/src/")) {
+        const importMatch = line.match(
+          /(?:from\s+['"]|import\s+['"]|require\s*\(\s*['"])(\.\.\/(?:\.\.\/){2,}[^'"]+)['"]/,
+        );
+        if (importMatch) {
+          violations.push(
+            `${filePath}:${lineNum}: deep relative import "${importMatch[1]}" (use path aliases)`,
+          );
+        }
+      }
+    }
+  }
+
+  return { passed: violations.length === 0, violations };
+}
+
+/**
+ * Build a human-readable summary from validation results
+ */
+function buildSummary(result: Omit<ValidationResult, "summary">): string {
+  const parts: string[] = [];
+
+  if (result.typeCheck.passed) {
+    parts.push("Type-check passed");
+  } else {
+    parts.push(`Type-check failed (${result.typeCheck.errors.length} error(s))`);
+  }
+
+  if (result.tests.skipped) {
+    parts.push("Tests skipped (no test files)");
+  } else if (result.tests.passed) {
+    parts.push("Tests passed");
+  } else {
+    parts.push(`Tests failed (${result.tests.errors.length} error(s))`);
+  }
+
+  if (result.conventions.passed) {
+    parts.push("Conventions clean");
+  } else {
+    parts.push(
+      `Convention violations (${result.conventions.violations.length})`,
+    );
+  }
+
+  const status = result.passed ? "PASSED" : "FAILED";
+  return `Validation ${status}: ${parts.join("; ")}`;
+}
+
+/**
+ * Validate build output by running type-check, tests, and convention scans
+ *
+ * @param options - Validation configuration
+ * @returns Aggregated validation result with human-readable summary
+ */
+export async function validateBuildOutput(
+  options: ValidateOptions,
+): Promise<ValidationResult> {
+  const { projectRoot, filesModified, skipTests, skipTypeCheck } = options;
+
+  // Run type-check
+  const typeCheck = skipTypeCheck
+    ? { passed: true, errors: [] as string[] }
+    : await runTypeCheck(projectRoot);
+
+  // Run tests
+  const tests = skipTests
+    ? { passed: true, errors: [] as string[], skipped: true }
+    : await runTests(projectRoot);
+
+  // Run convention scan
+  const conventions = await scanConventions(filesModified);
+
+  // Type-check and tests must pass; conventions are advisory
+  const passed = typeCheck.passed && tests.passed;
+
+  const partial = { passed, typeCheck, tests, conventions };
+  const summary = buildSummary(partial);
+
+  return { ...partial, summary };
+}
+
+/**
+ * Format validation errors into a concise string suitable for a build-fix prompt
+ * Groups by category (type errors, test failures, convention violations)
+ * Keeps output under ~500 tokens
+ *
+ * @param result - The validation result to format
+ * @returns Formatted error string for prompt injection
+ */
+export function formatValidationErrors(result: ValidationResult): string {
+  if (result.passed && result.conventions.passed) {
+    return "All checks passed. No errors to fix.";
+  }
+
+  const sections: string[] = [];
+
+  // Type errors
+  if (!result.typeCheck.passed && result.typeCheck.errors.length > 0) {
+    const errors = result.typeCheck.errors.slice(0, 10);
+    sections.push("## Type Errors");
+    for (const err of errors) {
+      sections.push(`- ${err}`);
+    }
+    if (result.typeCheck.errors.length > 10) {
+      sections.push(
+        `- ... and ${result.typeCheck.errors.length - 10} more type error(s)`,
+      );
+    }
+  }
+
+  // Test failures
+  if (!result.tests.passed && !result.tests.skipped && result.tests.errors.length > 0) {
+    const errors = result.tests.errors.slice(0, 10);
+    sections.push("## Test Failures");
+    for (const err of errors) {
+      sections.push(`- ${err}`);
+    }
+    if (result.tests.errors.length > 10) {
+      sections.push(
+        `- ... and ${result.tests.errors.length - 10} more test failure(s)`,
+      );
+    }
+  }
+
+  // Convention violations
+  if (!result.conventions.passed && result.conventions.violations.length > 0) {
+    const violations = result.conventions.violations.slice(0, 10);
+    sections.push("## Convention Violations");
+    for (const v of violations) {
+      sections.push(`- ${v}`);
+    }
+    if (result.conventions.violations.length > 10) {
+      sections.push(
+        `- ... and ${result.conventions.violations.length - 10} more violation(s)`,
+      );
+    }
+  }
+
+  return sections.join("\n");
+}


### PR DESCRIPTION
## Summary

Closes #195 — The ADW orchestrator was bypassing `.claude/agents/experts/` agent definitions entirely, using 5-line inline prompt stubs instead of the real 300+ line agent prompts. This PR closes all three gaps identified in the issue.

### Gap 1: Agent prompts loaded from `.md` files
- New `prompt-loader.ts` module with `loadAgentPrompt()` — reads agent `.md` files, strips YAML frontmatter, returns full markdown body
- `executePlan`, `executeBuild`, `executeImprove` now use loaded prompts (zero inline prompt text)
- Variables (`SPEC`, `AUTOMATION_MODE`, etc.) appended via `buildPhasePrompt()` rather than being the entire prompt

### Gap 2: Validate phase with build→fix loop
- New `validator.ts` module with `validateBuildOutput()` — runs `bunx tsc --noEmit`, `bun test`, and convention scan (console.* usage, deep relative imports)
- New validate phase inserted between build and improve in the pipeline
- On validation failure, build is re-invoked with error context (max 2 retries)
- `PHASE_ORDER` updated: `["analysis", "plan", "build", "validate", "improve"]`

### Gap 3: Pre-build expertise injection
- `loadExpertiseConventions()` extracts compact conventions from `expertise.yaml` (~500 tokens)
- Injected into build prompt as `EXPERTISE_CONVENTIONS` variable
- Complements dynamic curated context with static domain knowledge

## Files Changed

| File | Change |
|------|--------|
| `automation/src/prompt-loader.ts` | **New** — 3 exports: `loadAgentPrompt`, `loadExpertiseConventions`, `buildPhasePrompt` |
| `automation/src/validator.ts` | **New** — 4 exports: `ValidationResult`, `ValidateOptions`, `validateBuildOutput`, `formatValidationErrors` |
| `automation/src/orchestrator.ts` | **Modified** — Phase functions refactored, validate phase + build-fix loop added |

## Test plan

- [x] `bunx tsc --noEmit` — zero type errors
- [x] `bun test` — 99 pass, 0 fail (192 expect calls)
- [x] Zero inline prompts verified in `executePlan`, `executeBuild`, `executeImprove`
- [ ] End-to-end ADW run on a test issue to validate prompt loading with SDK `query()`
- [ ] Intentional type error in spec to verify validate phase catches it