### PR TITLE
fix(indexer): resolve path alias resolution bugs (#197)

### DIFF
--- a/.claude/commands/do-teams.md
+++ b/.claude/commands/do-teams.md
@@ -113,7 +113,7 @@ Task(
 
     ## CONTEXT
     EXPERTISE: Load expertise per your agent's context contract.
-    Path: /Users/jayminwest/Projects/kotadb/.claude/agents/experts/{domain}/expertise.yaml
+    Path: .claude/agents/experts/{domain}/expertise.yaml
     TEAM: {team-name}
 
     Read the expertise file before starting work.
@@ -167,7 +167,7 @@ Task(
 
     ## CONTEXT
     EXPERTISE: Load expertise per your agent's context contract.
-    Path: /Users/jayminwest/Projects/kotadb/.claude/agents/experts/{domain}/expertise.yaml
+    Path: .claude/agents/experts/{domain}/expertise.yaml
     TEAM: {team-name}
 
     Read the expertise file. Apply {domain} lens to analysis.
@@ -340,8 +340,8 @@ Teammates should format SendMessage content as JSON matching the coordination me
   "status": "complete",
   "summary": "Created preferences table with user_id FK and indexes",
   "filesModified": [
-    "/Users/jayminwest/Projects/kotadb/app/src/db/migrations/003_preferences.ts",
-    "/Users/jayminwest/Projects/kotadb/app/src/db/schema.ts"
+    "app/src/db/migrations/003_preferences.ts",
+    "app/src/db/schema.ts"
   ],
   "nextSteps": ["Run migration", "Add API handler"]
 }
@@ -424,7 +424,7 @@ Teammates load expertise through their agent's context contract rather than raw 
 
 **Pass the expertise path in the prompt as a fallback:**
 ```
-EXPERTISE: /Users/jayminwest/Projects/kotadb/.claude/agents/experts/{domain}/expertise.yaml
+EXPERTISE: .claude/agents/experts/{domain}/expertise.yaml
 Read this file before starting work.
 ```
 

--- a/app/src/indexer/incremental.ts
+++ b/app/src/indexer/incremental.ts
@@ -332,7 +332,7 @@ async function indexChangedFilesInternal(
 					// Store references
 					if (references.length > 0) {
 						const updatedFiles = [...allIndexedFiles, { id: fileId, path: normalizedPath }];
-						const refCount = storeReferencesForFile(db, fileId, repositoryId, normalizedPath, references, updatedFiles, pathMappings);
+						const refCount = storeReferencesForFile(db, fileId, repositoryId, normalizedPath, references, updatedFiles, pathMappings, absoluteRoot);
 						result.referencesExtracted += refCount;
 					}
 				}
@@ -373,6 +373,7 @@ function storeReferencesForFile(
 	references: Reference[],
 	allFiles: Array<{ path: string }>,
 	pathMappings: PathMappings | null,
+	repoRoot?: string,
 ): number {
 	let count = 0;
 
@@ -386,7 +387,7 @@ function storeReferencesForFile(
 
 		let targetFilePath: string | null = null;
 		if (ref.referenceType === "import" && ref.metadata?.importSource) {
-			const resolved = resolveImport(ref.metadata.importSource, filePath, allFiles, pathMappings);
+			const resolved = resolveImport(ref.metadata.importSource, filePath, allFiles, pathMappings, repoRoot);
 			if (resolved) {
 				targetFilePath = normalizePath(resolved);
 			}

--- a/app/tests/indexer/import-resolver.test.ts
+++ b/app/tests/indexer/import-resolver.test.ts
@@ -150,6 +150,7 @@ describe("resolveImport with path aliases", () => {
 
 		const pathMappings = {
 			baseUrl: ".",
+			tsconfigDir: "",
 			paths: { "@api/*": ["src/api/*"] },
 		};
 
@@ -164,6 +165,7 @@ describe("resolveImport with path aliases", () => {
 
 		const pathMappings = {
 			baseUrl: ".",
+			tsconfigDir: "",
 			paths: { "@api/*": ["src/api/*"] },
 		};
 
@@ -179,6 +181,7 @@ describe("resolveImport with path aliases", () => {
 
 		const pathMappings = {
 			baseUrl: ".",
+			tsconfigDir: "",
 			paths: { "@api/*": ["src/api/*"] },
 		};
 
@@ -195,6 +198,7 @@ describe("resolveImport with path aliases", () => {
 
 		const pathMappings = {
 			baseUrl: ".",
+			tsconfigDir: "",
 			paths: { "@db/*": ["src/db/*"] },
 		};
 
@@ -209,6 +213,7 @@ describe("resolveImport with path aliases", () => {
 
 		const pathMappings = {
 			baseUrl: ".",
+			tsconfigDir: "",
 			paths: { "@api/*": ["src/api/*"] },
 		};
 
@@ -233,6 +238,7 @@ describe("resolveImport with path aliases", () => {
 
 		const pathMappings = {
 			baseUrl: ".",
+			tsconfigDir: "",
 			paths: { "@shared/*": ["src/shared/*", "packages/shared/*"] },
 		};
 

--- a/app/tests/indexer/path-resolver.test.ts
+++ b/app/tests/indexer/path-resolver.test.ts
@@ -248,6 +248,7 @@ describe("path-resolver", () => {
 			const files = new Set(["src/api/routes.ts"]);
 			const mappings = {
 				baseUrl: ".",
+				tsconfigDir: "",
 				paths: { "@api/*": ["src/api/*"] },
 			};
 
@@ -260,6 +261,7 @@ describe("path-resolver", () => {
 			const files = new Set(["packages/shared/utils.ts"]);
 			const mappings = {
 				baseUrl: ".",
+				tsconfigDir: "",
 				paths: { "@shared/*": ["src/shared/*", "packages/shared/*"] },
 			};
 
@@ -272,6 +274,7 @@ describe("path-resolver", () => {
 			const files = new Set(["src/api/routes.ts"]);
 			const mappings = {
 				baseUrl: ".",
+				tsconfigDir: "",
 				paths: { "@api/*": ["src/api/*"] },
 			};
 
@@ -284,6 +287,7 @@ describe("path-resolver", () => {
 			const files = new Set(["src/db/schema.ts"]);
 			const mappings = {
 				baseUrl: ".",
+				tsconfigDir: "",
 				paths: { "@db/*": ["src/db/*"] },
 			};
 
@@ -296,6 +300,7 @@ describe("path-resolver", () => {
 			const files = new Set(["src/api/routes.ts"]);
 			const mappings = {
 				baseUrl: ".",
+				tsconfigDir: "",
 				paths: { "@api/*": ["src/api/*"] },
 			};
 
@@ -308,6 +313,7 @@ describe("path-resolver", () => {
 			const files = new Set(["src/api/routes.ts"]);
 			const mappings = {
 				baseUrl: ".",
+				tsconfigDir: "",
 				paths: { "@api/*": ["src/api/*"] },
 			};
 
@@ -320,6 +326,7 @@ describe("path-resolver", () => {
 			const files = new Set<string>([]);
 			const mappings = {
 				baseUrl: ".",
+				tsconfigDir: "",
 				paths: { "@api/*": ["src/api/*"] },
 			};
 
@@ -334,6 +341,7 @@ describe("path-resolver", () => {
 			]);
 			const mappings = {
 				baseUrl: ".",
+				tsconfigDir: "",
 				paths: { "@api": ["src/api/index.ts"] },
 			};
 			
@@ -349,6 +357,7 @@ describe("path-resolver", () => {
 			]);
 			const mappings = {
 				baseUrl: ".",
+				tsconfigDir: "",
 				paths: { "@api/*": ["src/api/*"] },
 			};
 			
@@ -365,6 +374,7 @@ describe("path-resolver", () => {
 			]);
 			const mappings = {
 				baseUrl: "src",
+				tsconfigDir: "",
 				paths: { "@api/*": ["api/*"] },
 			};
 			
@@ -386,6 +396,7 @@ describe("path-resolver", () => {
 			
 			const mappings = {
 				baseUrl: ".",
+				tsconfigDir: "",
 				paths: { 
 					"@api/*": ["src/api/*"],
 					"@db/*": ["src/db/*"],

--- a/app/tests/mcp/path-alias-resolution.e2e.test.ts
+++ b/app/tests/mcp/path-alias-resolution.e2e.test.ts
@@ -1,19 +1,51 @@
 /**
- * E2E tests for path alias resolution in full indexing workflow.
- * 
- * Tests real tsconfig.json parsing, import resolution, and MCP tool integration.
- * Uses temporary fixtures within the workspace.
+ * E2E tests for path alias resolution across monorepo-like structures.
+ *
+ * Following antimocking philosophy: uses real in-memory SQLite databases
+ * and real filesystem fixtures to test the full path alias pipeline.
+ *
+ * Test Coverage:
+ * - parseTsConfig: Discovers tsconfig.json in subdirectories (Bug #1)
+ * - resolvePathAlias: Returns repo-root-relative paths (Bug #2)
+ * - resolveImport: .js extension imports resolve to .ts files (Bug #3)
+ * - Full indexing workflow: All path alias imports resolve correctly (Bug #4)
+ * - search_dependencies: Finds path alias edges after indexing
+ * - .js→.ts resolution: Relative .js imports resolve during indexing
+ *
+ * @module tests/mcp/path-alias-resolution-e2e
  */
 
 import { describe, expect, test, beforeAll, afterAll } from "bun:test";
-import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { mkdirSync, writeFileSync, existsSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
+import { parseTsConfig, resolvePathAlias } from "@indexer/path-resolver.js";
+import { resolveImport } from "@indexer/import-resolver.js";
 import { runIndexingWorkflow } from "@api/queries.js";
 import { executeSearchDependencies } from "@mcp/tools.js";
 import { closeGlobalConnections, getGlobalDatabase } from "@db/sqlite/index.js";
 import type { KotaDatabase } from "@db/sqlite/sqlite-client.js";
 import { createTempDir, cleanupTempDir } from "../helpers/db.js";
+
+// ============================================================================
+// Monorepo Fixture Layout
+// ============================================================================
+//
+// fixture-root/                    <- repo root (localPath)
+// ├── app/                         <- subdirectory with tsconfig
+// │   ├── tsconfig.json            <- path aliases defined here
+// │   ├── src/
+// │   │   ├── index.ts             <- imports via @api/routes.js, @db/schema.js
+// │   │   ├── api/
+// │   │   │   ├── routes.ts        <- target file
+// │   │   │   └── index.ts         <- imports @db/schema.js
+// │   │   ├── db/
+// │   │   │   └── schema.ts        <- target file
+// │   │   └── utils/
+// │   │       └── helper.ts        <- imported via ../utils/helper.js
+// │   └── shared/
+// │       └── types.ts             <- imported via relative .js extension
+// ============================================================================
 
 describe("path alias resolution E2E", () => {
   let tempDir: string;
@@ -22,94 +54,124 @@ describe("path alias resolution E2E", () => {
   let db: KotaDatabase;
   let originalDbPath: string | undefined;
   let repoId: string;
+  let repoName: string;
   const requestId = "test-request";
   const userId = "test-user";
-  
+
   beforeAll(async () => {
-    // Create test database
+    // Set up isolated test database
     tempDir = createTempDir("path-alias-e2e-");
     dbPath = join(tempDir, "test.db");
     originalDbPath = process.env.KOTADB_PATH;
     process.env.KOTADB_PATH = dbPath;
     closeGlobalConnections();
-    
-    // Create fixture directory WITHIN workspace for security check
+
+    // Create monorepo-like fixture WITHIN workspace for security check
     const workspaceRoot = process.cwd();
     fixtureDir = join(workspaceRoot, ".test-fixtures-e2e-" + randomUUID().slice(0, 8));
-    mkdirSync(join(fixtureDir, "src", "api"), { recursive: true });
-    mkdirSync(join(fixtureDir, "src", "db"), { recursive: true });
-    
-    // tsconfig.json with path aliases
+
+    // Build directory structure
+    mkdirSync(join(fixtureDir, "app", "src", "api"), { recursive: true });
+    mkdirSync(join(fixtureDir, "app", "src", "db"), { recursive: true });
+    mkdirSync(join(fixtureDir, "app", "src", "utils"), { recursive: true });
+    mkdirSync(join(fixtureDir, "app", "shared"), { recursive: true });
+
+    // tsconfig.json in app/ subdirectory (NOT at repo root)
     writeFileSync(
-      join(fixtureDir, "tsconfig.json"),
-      JSON.stringify({
-        compilerOptions: {
-          baseUrl: ".",
-          paths: {
-            "@api/*": ["src/api/*"],
-            "@db/*": ["src/db/*"],
+      join(fixtureDir, "app", "tsconfig.json"),
+      JSON.stringify(
+        {
+          compilerOptions: {
+            baseUrl: ".",
+            paths: {
+              "@api/*": ["src/api/*"],
+              "@db/*": ["src/db/*"],
+            },
           },
         },
-      })
+        null,
+        2,
+      ),
     );
-    
-    // Target files
-    writeFileSync(
-      join(fixtureDir, "src", "api", "routes.ts"),
-      "export const routes = [];"
-    );
-    
-    writeFileSync(
-      join(fixtureDir, "src", "db", "schema.ts"),
-      "export const schema = {};"
-    );
-    
-    // Importer files with path aliases
-    writeFileSync(
-      join(fixtureDir, "src", "index.ts"),
-      `import { routes } from '@api/routes';
-import { schema } from '@db/schema';
 
-export { routes, schema };`
-    );
-    
+    // Source files with path alias imports
     writeFileSync(
-      join(fixtureDir, "src", "api", "index.ts"),
-      `import { schema } from '@db/schema';
-
-export { schema };`
+      join(fixtureDir, "app", "src", "index.ts"),
+      [
+        'import { routes } from "@api/routes.js";',
+        'import { schema } from "@db/schema.js";',
+        'import { helper } from "../shared/types.js";',
+        "",
+        "export { routes, schema, helper };",
+      ].join("\n"),
     );
-    
+
+    writeFileSync(
+      join(fixtureDir, "app", "src", "api", "routes.ts"),
+      [
+        'import { schema } from "@db/schema.js";',
+        'import { helper } from "../utils/helper.js";',
+        "",
+        "export const routes = [schema, helper];",
+      ].join("\n"),
+    );
+
+    writeFileSync(
+      join(fixtureDir, "app", "src", "api", "index.ts"),
+      [
+        'import { schema } from "@db/schema.js";',
+        "",
+        "export { schema };",
+      ].join("\n"),
+    );
+
+    writeFileSync(
+      join(fixtureDir, "app", "src", "db", "schema.ts"),
+      'export const schema = { tables: [] };',
+    );
+
+    writeFileSync(
+      join(fixtureDir, "app", "src", "utils", "helper.ts"),
+      'export function helper(): string { return "help"; }',
+    );
+
+    writeFileSync(
+      join(fixtureDir, "app", "shared", "types.ts"),
+      'export const helper = "shared-types";',
+    );
+
     // Initialize database
     db = getGlobalDatabase();
-    
-    // Run full indexing workflow (parses tsconfig, resolves imports)
-    // This will create the repository automatically
-    const repoName = "test-repo-" + randomUUID().slice(0, 8);
+
+    // Run full indexing workflow
+    repoName = "test-repo-" + randomUUID().slice(0, 8);
     await runIndexingWorkflow({
       repository: repoName,
       localPath: fixtureDir,
     });
-    
-    // Get the created repository ID
+
+    // Get created repository ID
     const repo = db.queryOne<{ id: string }>(
-      `SELECT id FROM repositories WHERE full_name LIKE ?`,
-      [`local/${repoName}`]
+      "SELECT id FROM repositories WHERE full_name LIKE ?",
+      [`local/${repoName}`],
     );
     if (!repo) {
-      throw new Error("Repository not created");
+      throw new Error("Repository not created during fixture setup");
     }
     repoId = repo.id;
   });
-  
+
   afterAll(() => {
     // Clean up fixture directory
     try {
-      rmSync(fixtureDir, { recursive: true, force: true });
+      if (fixtureDir && existsSync(fixtureDir)) {
+        rmSync(fixtureDir, { recursive: true, force: true });
+      }
     } catch {
       // Ignore cleanup errors
     }
-    
+
+    // Restore environment
     if (originalDbPath !== undefined) {
       process.env.KOTADB_PATH = originalDbPath;
     } else {
@@ -118,79 +180,405 @@ export { schema };`
     closeGlobalConnections();
     cleanupTempDir(tempDir);
   });
-  
-  test("indexes files with path alias imports and resolves dependencies", () => {
-    // Verify path alias imports were resolved
-    const references = db.query<{ source_file_path: string; target_file_path: string | null; metadata: string }>(
-      `SELECT 
-         f.path as source_file_path,
-         r.target_file_path,
-         r.metadata
-       FROM indexed_references r
-       JOIN indexed_files f ON r.file_id = f.id
-       WHERE r.repository_id = ?
-       AND r.reference_type = 'import'`,
-      [repoId]
-    );
-    
-    // Find path alias imports
-    const aliasImports = references.filter(r => {
-      const metadata = JSON.parse(r.metadata || "{}");
-      return metadata.importSource?.startsWith("@");
+
+  // ==========================================================================
+  // Test 1: tsconfig.json discovery in subdirectory (Bug #1)
+  // ==========================================================================
+
+  describe("parseTsConfig()", () => {
+    test("should discover tsconfig.json in subdirectory", () => {
+      // parseTsConfig is called with the repo root (fixtureDir).
+      // The tsconfig.json is in fixtureDir/app/, not at fixtureDir root.
+      // After the fix, parseTsConfig should walk subdirectories to find it.
+      const mappings = parseTsConfig(fixtureDir);
+
+      // If parseTsConfig only checks the root, this will be null (Bug #1).
+      // After fix, it should find the tsconfig in app/ subdirectory.
+      expect(mappings).not.toBeNull();
+
+      if (mappings) {
+        expect(Object.keys(mappings.paths)).toContain("@api/*");
+        expect(Object.keys(mappings.paths)).toContain("@db/*");
+        expect(mappings.paths["@api/*"]).toEqual(["src/api/*"]);
+        expect(mappings.paths["@db/*"]).toEqual(["src/db/*"]);
+      }
     });
-    
-    expect(aliasImports.length).toBeGreaterThan(0);
-    
-    // All path alias imports should have resolved target_file_path
-    for (const ref of aliasImports) {
-      expect(ref.target_file_path).not.toBeNull();
-      expect(ref.target_file_path).toBeTruthy();
-      
-      const metadata = JSON.parse(ref.metadata || "{}");
-      
-      // Validate specific resolutions
-      if (metadata.importSource === "@api/routes") {
-        expect(ref.target_file_path).toContain("src/api/routes.ts");
+
+    test("should return null when no tsconfig.json exists anywhere", () => {
+      // Create a directory with no tsconfig at all
+      const emptyDir = join(tempDir, "no-tsconfig-" + randomUUID().slice(0, 8));
+      mkdirSync(emptyDir, { recursive: true });
+
+      const mappings = parseTsConfig(emptyDir);
+      expect(mappings).toBeNull();
+
+      rmSync(emptyDir, { recursive: true, force: true });
+    });
+
+    test("should find tsconfig.json at direct root level", () => {
+      // Verify parseTsConfig still works when tsconfig IS at root
+      const directDir = join(fixtureDir, "app");
+      const mappings = parseTsConfig(directDir);
+
+      expect(mappings).not.toBeNull();
+      if (mappings) {
+        expect(mappings.paths["@api/*"]).toEqual(["src/api/*"]);
       }
-      if (metadata.importSource === "@db/schema") {
-        expect(ref.target_file_path).toContain("src/db/schema.ts");
+    });
+  });
+
+  // ==========================================================================
+  // Test 2: Path alias resolution returns repo-root-relative paths (Bug #2)
+  // ==========================================================================
+
+  describe("resolvePathAlias()", () => {
+    test("should resolve path aliases to repo-root-relative paths", () => {
+      // Build a files Set with repo-root-relative paths (as stored in DB)
+      const files = new Set([
+        "app/src/api/routes.ts",
+        "app/src/api/index.ts",
+        "app/src/db/schema.ts",
+        "app/src/index.ts",
+        "app/src/utils/helper.ts",
+        "app/shared/types.ts",
+      ]);
+
+      // The mappings as parsed from tsconfig in app/ subdirectory.
+      // After fix, tsconfigDir should be factored into resolution.
+      const mappings = parseTsConfig(fixtureDir);
+      expect(mappings).not.toBeNull();
+
+      if (mappings) {
+        // @api/routes should resolve to app/src/api/routes.ts (repo-root-relative)
+        // Bug #2: without the fix, it resolves to src/api/routes.ts (tsconfig-relative)
+        const routesResult = resolvePathAlias(
+          "@api/routes",
+          fixtureDir,
+          files,
+          mappings,
+        );
+        expect(routesResult).toBe("app/src/api/routes.ts");
+
+        // @db/schema should resolve to app/src/db/schema.ts
+        const schemaResult = resolvePathAlias(
+          "@db/schema",
+          fixtureDir,
+          files,
+          mappings,
+        );
+        expect(schemaResult).toBe("app/src/db/schema.ts");
       }
-    }
+    });
+
+    test("should resolve path alias with .js extension to .ts file", () => {
+      const files = new Set([
+        "app/src/api/routes.ts",
+        "app/src/db/schema.ts",
+      ]);
+
+      const mappings = parseTsConfig(fixtureDir);
+      expect(mappings).not.toBeNull();
+
+      if (mappings) {
+        // Import uses .js extension but actual file is .ts
+        // Bug #3: .js→.ts substitution must work for path alias imports
+        const result = resolvePathAlias(
+          "@api/routes.js",
+          fixtureDir,
+          files,
+          mappings,
+        );
+
+        // Should resolve to the .ts file, not return null
+        // This tests that the resolver strips .js and tries .ts
+        expect(result).toBe("app/src/api/routes.ts");
+      }
+    });
+
+    test("should return null for unresolved alias", () => {
+      const files = new Set(["app/src/api/routes.ts"]);
+
+      const mappings = parseTsConfig(fixtureDir);
+      if (mappings) {
+        const result = resolvePathAlias(
+          "@unknown/module",
+          fixtureDir,
+          files,
+          mappings,
+        );
+        expect(result).toBeNull();
+      }
+    });
   });
-  
-  test("search_dependencies MCP tool finds path alias dependents", async () => {
-    // Search for dependents of routes.ts
-    const result = await executeSearchDependencies(
-      {
-        file_path: "src/api/routes.ts",
-        direction: "dependents",
-        depth: 1,
-        repository: repoId,
-      },
-      requestId,
-      userId
-    ) as { dependents: { direct: string[]; count: number } };
-    
-    // Should find src/index.ts (imports via @api/routes)
-    expect(result.dependents.direct).toContain("src/index.ts");
-    expect(result.dependents.count).toBeGreaterThanOrEqual(1);
+
+  // ==========================================================================
+  // Test 3: .js extension imports resolve to .ts files (Bug #3)
+  // ==========================================================================
+
+  describe("resolveImport() .js→.ts resolution", () => {
+    test("should resolve relative .js imports to .ts files", () => {
+      // Files as stored in DB (repo-root-relative)
+      const files = [
+        { path: "app/src/utils/helper.ts" },
+        { path: "app/src/api/routes.ts" },
+      ];
+
+      // Import from routes.ts using .js extension for a .ts file
+      const result = resolveImport(
+        "../utils/helper.js",
+        "app/src/api/routes.ts",
+        files,
+        null,
+      );
+
+      // Bug #3: without .js→.ts substitution, this returns null
+      // After fix: should resolve to the .ts file
+      expect(result).toBe("app/src/utils/helper.ts");
+    });
+
+    test("should resolve relative .js import to actual .js file when it exists", () => {
+      const files = [
+        { path: "app/src/utils/helper.js" },
+        { path: "app/src/api/routes.ts" },
+      ];
+
+      const result = resolveImport(
+        "../utils/helper.js",
+        "app/src/api/routes.ts",
+        files,
+        null,
+      );
+
+      // When the .js file exists, it should resolve to it directly
+      expect(result).toBe("app/src/utils/helper.js");
+    });
+
+    test("should resolve path alias import with .js extension via mappings", () => {
+      const files = [
+        { path: "app/src/db/schema.ts" },
+        { path: "app/src/api/routes.ts" },
+      ];
+
+      const mappings = parseTsConfig(fixtureDir);
+      expect(mappings).not.toBeNull();
+
+      if (mappings) {
+        // @db/schema.js should resolve to app/src/db/schema.ts
+        const result = resolveImport(
+          "@db/schema.js",
+          "app/src/api/routes.ts",
+          files,
+          mappings,
+        );
+
+        expect(result).toBe("app/src/db/schema.ts");
+      }
+    });
   });
-  
-  test("resolves transitive path alias dependencies", async () => {
-    // schema.ts has dependents: index.ts (@db/schema) and api/index.ts (@db/schema)
-    const result = await executeSearchDependencies(
-      {
-        file_path: "src/db/schema.ts",
-        direction: "dependents",
-        depth: 2,
-        repository: repoId,
-      },
-      requestId,
-      userId
-    ) as { dependents: { direct: string[]; indirect: Record<string, string[]> } };
-    
-    // Direct dependents
-    expect(result.dependents.direct).toContain("src/index.ts");
-    expect(result.dependents.direct).toContain("src/api/index.ts");
+
+  // ==========================================================================
+  // Test 4: Full indexing workflow resolves all path alias imports
+  // ==========================================================================
+
+  describe("full indexing workflow", () => {
+    test("should resolve all path alias imports with non-null target_file_path", () => {
+      // Query import references from the indexed repository
+      const references = db.query<{
+        source_file_path: string;
+        target_file_path: string | null;
+        metadata: string;
+      }>(
+        `SELECT
+           f.path as source_file_path,
+           r.target_file_path,
+           r.metadata
+         FROM indexed_references r
+         JOIN indexed_files f ON r.file_id = f.id
+         WHERE r.repository_id = ?
+           AND r.reference_type = 'import'`,
+        [repoId],
+      );
+
+      // Find all path alias imports (those with @ prefix in importSource)
+      const aliasImports = references.filter((r) => {
+        const metadata = JSON.parse(r.metadata || "{}");
+        return metadata.importSource?.startsWith("@");
+      });
+
+      // There should be path alias imports found
+      expect(aliasImports.length).toBeGreaterThan(0);
+
+      // KEY ACCEPTANCE CRITERION: ALL path alias imports must be resolved
+      const unresolvedAliases = aliasImports.filter(
+        (r) => r.target_file_path === null || r.target_file_path === "",
+      );
+      expect(unresolvedAliases).toEqual([]);
+
+      // Verify specific resolution targets
+      for (const ref of aliasImports) {
+        expect(ref.target_file_path).not.toBeNull();
+        expect(ref.target_file_path).toBeTruthy();
+
+        const metadata = JSON.parse(ref.metadata || "{}");
+
+        if (metadata.importSource === "@api/routes" || metadata.importSource === "@api/routes.js") {
+          expect(ref.target_file_path).toContain("api/routes.ts");
+        }
+        if (metadata.importSource === "@db/schema" || metadata.importSource === "@db/schema.js") {
+          expect(ref.target_file_path).toContain("db/schema.ts");
+        }
+      }
+    });
+
+    test("should also resolve relative imports correctly", () => {
+      const references = db.query<{
+        source_file_path: string;
+        target_file_path: string | null;
+        metadata: string;
+      }>(
+        `SELECT
+           f.path as source_file_path,
+           r.target_file_path,
+           r.metadata
+         FROM indexed_references r
+         JOIN indexed_files f ON r.file_id = f.id
+         WHERE r.repository_id = ?
+           AND r.reference_type = 'import'`,
+        [repoId],
+      );
+
+      // Find relative imports (those starting with . in importSource)
+      const relativeImports = references.filter((r) => {
+        const metadata = JSON.parse(r.metadata || "{}");
+        return metadata.importSource?.startsWith(".");
+      });
+
+      // Relative imports should exist and be resolved
+      if (relativeImports.length > 0) {
+        for (const ref of relativeImports) {
+          expect(ref.target_file_path).not.toBeNull();
+        }
+      }
+    });
+  });
+
+  // ==========================================================================
+  // Test 5: search_dependencies finds path alias edges
+  // ==========================================================================
+
+  describe("search_dependencies MCP tool", () => {
+    test("should find dependents of a file imported via path alias", async () => {
+      // routes.ts is imported via @api/routes from index.ts
+      const result = (await executeSearchDependencies(
+        {
+          file_path: "app/src/api/routes.ts",
+          direction: "dependents",
+          depth: 1,
+          repository: repoId,
+        },
+        requestId,
+        userId,
+      )) as { dependents: { direct: string[]; count: number } };
+
+      // index.ts imports @api/routes, so it should be a dependent
+      expect(result.dependents.direct).toContain("app/src/index.ts");
+      expect(result.dependents.count).toBeGreaterThanOrEqual(1);
+    });
+
+    test("should find dependencies of a file that uses path aliases", async () => {
+      // index.ts imports @api/routes and @db/schema
+      const result = (await executeSearchDependencies(
+        {
+          file_path: "app/src/index.ts",
+          direction: "dependencies",
+          depth: 1,
+          repository: repoId,
+        },
+        requestId,
+        userId,
+      )) as { dependencies: { direct: string[]; count: number } };
+
+      // Should include files imported via path aliases
+      expect(result.dependencies.direct).toContain("app/src/api/routes.ts");
+      expect(result.dependencies.direct).toContain("app/src/db/schema.ts");
+    });
+
+    test("should find transitive path alias dependencies", async () => {
+      // schema.ts is imported by index.ts AND api/index.ts AND api/routes.ts
+      const result = (await executeSearchDependencies(
+        {
+          file_path: "app/src/db/schema.ts",
+          direction: "dependents",
+          depth: 2,
+          repository: repoId,
+        },
+        requestId,
+        userId,
+      )) as { dependents: { direct: string[]; indirect: Record<string, string[]> } };
+
+      // Direct dependents: files that import @db/schema
+      expect(result.dependents.direct).toContain("app/src/index.ts");
+      expect(result.dependents.direct).toContain("app/src/api/index.ts");
+      expect(result.dependents.direct).toContain("app/src/api/routes.ts");
+    });
+  });
+
+  // ==========================================================================
+  // Test 6: .js→.ts resolution in relative imports during indexing
+  // ==========================================================================
+
+  describe(".js→.ts relative import resolution during indexing", () => {
+    test("should resolve .js extension imports to .ts files in the database", () => {
+      // Query for imports that used .js extension in source but should resolve to .ts
+      const references = db.query<{
+        source_file_path: string;
+        target_file_path: string | null;
+        metadata: string;
+      }>(
+        `SELECT
+           f.path as source_file_path,
+           r.target_file_path,
+           r.metadata
+         FROM indexed_references r
+         JOIN indexed_files f ON r.file_id = f.id
+         WHERE r.repository_id = ?
+           AND r.reference_type = 'import'`,
+        [repoId],
+      );
+
+      // Find imports that used .js extension
+      const jsExtImports = references.filter((r) => {
+        const metadata = JSON.parse(r.metadata || "{}");
+        return (
+          metadata.importSource?.endsWith(".js") ||
+          metadata.importSource?.includes(".js")
+        );
+      });
+
+      // All .js imports should have resolved target paths pointing to .ts files
+      for (const ref of jsExtImports) {
+        expect(ref.target_file_path).not.toBeNull();
+        // The resolved path should end in .ts (the actual file)
+        if (ref.target_file_path) {
+          expect(ref.target_file_path.endsWith(".ts")).toBe(true);
+        }
+      }
+    });
+
+    test("should have indexed all fixture files", () => {
+      const files = db.query<{ path: string }>(
+        "SELECT path FROM indexed_files WHERE repository_id = ? ORDER BY path",
+        [repoId],
+      );
+
+      const paths = files.map((f) => f.path);
+
+      // All fixture files should be indexed
+      expect(paths).toContainEqual(expect.stringContaining("api/routes.ts"));
+      expect(paths).toContainEqual(expect.stringContaining("api/index.ts"));
+      expect(paths).toContainEqual(expect.stringContaining("db/schema.ts"));
+      expect(paths).toContainEqual(expect.stringContaining("index.ts"));
+      expect(paths).toContainEqual(expect.stringContaining("utils/helper.ts"));
+    });
   });
 });

--- a/docs/testing-reports/mcp-tools-test-report.md
+++ b/docs/testing-reports/mcp-tools-test-report.md
@@ -363,8 +363,8 @@ A Model Context Protocol (MCP) server that provides tools for car customization 
 ## Testing Artifacts
 
 All test scripts and results are available in:
-- `/Users/jayminwest/Projects/kota-db-ts/test-mcp-tools.ts` - Comprehensive MCP tool testing
-- `/Users/jayminwest/Projects/kota-db-ts/test-dependencies.ts` - Targeted dependency analysis testing
+- `test-mcp-tools.ts` - Comprehensive MCP tool testing
+- `test-dependencies.ts` - Targeted dependency analysis testing
 
 ## Conclusion
 


### PR DESCRIPTION
## Summary

Fixes 4 interacting bugs that caused `search_dependencies` and `analyze_change_impact` MCP tools to miss the vast majority of import edges for any TypeScript project using path aliases or monorepo structures.

**Before:** `search_dependencies` on `app/src/mcp/tools.ts` resolved only 25% of imports (5/20). Path alias imports (`@api/*`, `@db/*`, etc.) all returned `target_file_path = NULL`.

**After:** All path alias and `.js`-extension imports resolve correctly to their target files.

### Bug Fixes

| Bug | Root Cause | Fix |
|-----|-----------|-----|
| **tsconfig discovery** | `parseTsConfig()` only checked repo root — missed `app/tsconfig.json` in monorepos | Walk subdirectories breadth-first (max 3 levels), skip node_modules/dist/.git |
| **Path format mismatch** | Resolved paths were tsconfig-relative (`src/api/routes.ts`) but DB stores repo-root-relative (`app/src/api/routes.ts`) | Added `tsconfigDir` field to `PathMappings`; resolve relative to repo root |
| **.js→.ts mapping** | `.js` extension imports failed exact lookup — no substitution to `.ts` attempted | Added `EXTENSION_MAP` (.js→.ts, .jsx→.tsx, .mjs→.mts, .cjs→.cts) in both resolvers |
| **Project root threading** | `determineProjectRoot()` used filesystem heuristics on relative DB paths — unreliable | Added optional `repoRoot` parameter to `resolveImport()`; threaded through all call sites |

### Files Changed

- `app/src/indexer/path-resolver.ts` — tsconfig discovery + tsconfigDir + extension mapping
- `app/src/indexer/import-resolver.ts` — .js→.ts substitution + repoRoot parameter
- `app/src/api/queries.ts` — thread repoRoot through storeReferences → resolveImport
- `app/src/indexer/incremental.ts` — pass absoluteRoot to resolveImport
- `app/tests/indexer/import-resolver.test.ts` — add tsconfigDir to test fixtures
- `app/tests/indexer/path-resolver.test.ts` — add tsconfigDir to test fixtures
- `app/tests/mcp/path-alias-resolution.e2e.test.ts` — comprehensive rewrite (16 tests)

## Test plan

- [x] `bunx tsc --noEmit` — zero type errors
- [x] Pre-commit hooks pass (type-check + lint)
- [x] 39 unit tests pass (path-resolver + import-resolver)
- [x] 16 E2E tests pass (monorepo tsconfig discovery, path format alignment, .js→.ts resolution, full indexing workflow, search_dependencies integration)
- [ ] Re-index KotaDB and verify zero NULL `target_file_path` for `@` imports
- [ ] Manual verification: `search_dependencies` on `app/src/mcp/tools.ts` finds all path alias edges

Closes #197